### PR TITLE
trurl: now --set URL encodes by default

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -22,6 +22,7 @@ my @t = (
     "--url https://curl.se/we/are.html --get '{port}'|443",
     "--url https://curl.se/hello --append path=you|https://curl.se/hello/you",
     "--url \"https://curl.se?name=hello\" --append query=search=string|https://curl.se/?name=hello&search=string",
+    "--url https://curl.se/hello --set user=:hej:|https://%3ahej%3a\@curl.se/hello",
 );
 
 for my $c (@t) {

--- a/trurl.1
+++ b/trurl.1
@@ -46,12 +46,16 @@ For query, this URL encodes and appends this segment to the query, separated
 with an ampersand (&). If the segment contains an equal sign ('=') that will
 be kept verbatim and both sides of the first occrance will be URL encoded
 separately.
-.IP "--set [component]=[data]"
+.IP "--set [component][:]=[data]"
 Set this URL component. Setting blank string ("") will clear it from the
 URL.
 
 The following components can be set: url, scheme, user, password,
 options, host, port, path, query, fragment and zoneid.
+
+If a simple "="-assignment is used, the data is URL encoded when applied. If
+":=" is used, the data is assumed to already be URL encoded and will be stored
+as-is.
 .SH "OUTPUT OPTIONS"
 .IP "--get [format]"
 Output data according to the provided format string. Components from the URL

--- a/trurl.c
+++ b/trurl.c
@@ -350,15 +350,22 @@ static void set(CURLU *uh,
     char *set = node->data;
     int i;
     char *ptr = strchr(set, '=');
-    if(ptr) {
+    if(ptr && (ptr > set)) {
       size_t vlen = ptr-set;
+      bool urlencode = true;
       bool found = false;
+      if(ptr[-1] == ':') {
+        urlencode = false;
+        vlen--;
+      }
       for(i=0; variables[i].name; i++) {
         if((strlen(variables[i].name) == vlen) &&
            !strncasecmp(set, variables[i].name, vlen)) {
           if(varset[i])
             help("A component can only be set once per URL");
-          curl_url_set(uh, variables[i].part, ptr+1, CURLU_NON_SUPPORT_SCHEME);
+          curl_url_set(uh, variables[i].part, ptr+1,
+                       CURLU_NON_SUPPORT_SCHEME|
+                       (urlencode ? CURLU_URLENCODE : 0) );
           found = true;
           varset[i] = true;
           break;
@@ -367,6 +374,8 @@ static void set(CURLU *uh,
       if(!found)
         help("Set unknown component");
     }
+    else
+      help("invalid --set syntax");
   }
 }
 


### PR DESCRIPTION
And allows := to store non-encoded strings.

Updated docs and added a test case