### PR TITLE
trurl: add --trim

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ command line tool for URL parsing and manipulation
       "fragment": "frag"
     }
   ]
+
+  $ trurl "https://example.com?search=hello&utm_source=tracker" --trim query="utm_*"
+  https://example.com/?search=hello
 ~~~
 
 ## Install

--- a/test.pl
+++ b/test.pl
@@ -26,6 +26,12 @@ my @t = (
     "--url \"https://curl.se?name=hello\" --append query=search=string|https://curl.se/?name=hello&search=string",
     "--url https://curl.se/hello --set user=:hej:|https://%3ahej%3a\@curl.se/hello",
     "localhost --append query=hello=foo|http://localhost/?hello=foo",
+    "\"https://example.com?search=hello&utm_source=tracker\" --trim query=\"utm_*\"|https://example.com/?search=hello",
+    "\"https://example.com?search=hello&utm_source=tracker&more=data\" --trim query=\"utm_*\"|https://example.com/?search=hello&more=data",
+    "\"https://example.com?search=hello&more=data\" --trim query=\"utm_*\"|https://example.com/?search=hello&more=data",
+    "\"https://example.com?utm_source=tracker\" --trim query=\"utm_*\"|https://example.com/",
+    "\"https://example.com?search=hello&utm_source=tracker&more=data\" --trim query=\"utm_source\"|https://example.com/?search=hello&more=data",
+    "\"https://example.com?search=hello&utm_source=tracker&more=data\" --trim query=\"utm_source\" --trim query=more --trim query=search|https://example.com/",
 );
 
 for my $c (@t) {

--- a/trurl.1
+++ b/trurl.1
@@ -56,6 +56,12 @@ options, host, port, path, query, fragment and zoneid.
 If a simple "="-assignment is used, the data is URL encoded when applied. If
 ":=" is used, the data is assumed to already be URL encoded and will be stored
 as-is.
+.IP "--trim [component]=[what]"
+Trims data off a component. Currently this can only trim a query component.
+
+"what" is specified as a full word or as a word prefix (using a single
+trailing asterisk) which make trurl remove tuples from the query string that
+match the instruction.
 .SH "OUTPUT OPTIONS"
 .IP "-g, --get [format]"
 Output data according to the provided format string. Components from the URL
@@ -129,5 +135,9 @@ $ trurl "https://fake.host/hello#frag" --set user=::moo:: --json
     "fragment": "frag"
   }
 ]
+.IP "Remove tracking tuples from query"
+$ trurl "https://example.com?search=hello&utm_source=tracker" --trim query="utm_*"
+https://example.com/?search=hello
+
 .SH WWW
 https://github.com/curl/trurl


### PR DESCRIPTION
--trim can remove (parts of) components. Starting out with query support for removing specific "tuples".

Man page and README updates. Added test cases.

Fixes #50