### PR TITLE
Add an INSTALL variable to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,17 @@ PREFIX ?= /usr/local
 BINDIR ?= $(DESTDIR)$(PREFIX)/bin
 MANDIR ?= $(DESTDIR)$(PREFIX)/share/man/man1
 
+INSTALL = install
+
 $(TARGET): $(OBJS)
 
 trurl.o:trurl.c version.h
 
 install:
-	install -d $(BINDIR)
-	install -m 0755 $(TARGET) $(BINDIR)
-	install -d $(MANDIR)
-	install -m 0644 $(MANUAL) $(MANDIR)
+	$(INSTALL) -d $(BINDIR)
+	$(INSTALL) -m 0755 $(TARGET) $(BINDIR)
+	$(INSTALL) -d $(MANDIR)
+	$(INSTALL) -m 0644 $(MANUAL) $(MANDIR)
 
 clean:
 	rm -f $(OBJS) $(TARGET)


### PR DESCRIPTION
This is useful to distribution packagers who may wish to set

```sh
INSTALL='install -p'
```

in order to preserve timestamps from the source tarball.

https://docs.fedoraproject.org/en-US/packaging-guidelines/#_timestamps