### PR TITLE
Build and run tests on windows

### DIFF
--- a/test-json.pl
+++ b/test-json.pl
@@ -32,7 +32,7 @@ while (my($i, $o) = each %t) {
     $o =~ s/[ \t\r\n]+/ /g;
 
     # A future version should also check stderr
-    my @out = `./trurl --json $i 2>/dev/null`;
+    my @out = ($^O eq 'MSWin32')?`.\\trurl.exe --json $i 2>nul`:`./trurl --json $i 2>/dev/null`;
     my $result = join("", @out);
     chomp $result;
     $result =~ s/[ \t\r\n]+/ /g;

--- a/test.pl
+++ b/test.pl
@@ -19,9 +19,9 @@ my @t = (
     "--set host=example.com --set scheme=ftp|ftp://example.com/",
     "--url https://curl.se/we/are.html --redirect here.html|https://curl.se/we/here.html",
     "--url https://curl.se/we/../are.html --set port=8080|https://curl.se:8080/are.html",
-    "--url https://curl.se/we/are.html --get '{path}'|/we/are.html",
-    "--url https://curl.se/we/are.html --get '{port}'|443",
-    "--url https://curl.se/we/are.html -g '{port}'|443",
+    "--url https://curl.se/we/are.html --get \"{path}\"|/we/are.html",
+    "--url https://curl.se/we/are.html --get \"{port}\"|443",
+    "--url https://curl.se/we/are.html -g \"{port}\"|443",
     "--url https://curl.se/hello --append path=you|https://curl.se/hello/you",
     "--url \"https://curl.se?name=hello\" --append query=search=string|https://curl.se/?name=hello&search=string",
     "--url https://curl.se/hello --set user=:hej:|https://%3ahej%3a\@curl.se/hello",
@@ -37,7 +37,7 @@ my @t = (
 for my $c (@t) {
     my ($i, $o) = split(/\|/, $c);
     # A future version should also check stderr
-    my @out = `./trurl $i 2>/dev/null`;
+    my @out = ($^O eq 'MSWin32')?`.\\trurl.exe $i 2>nul`:`./trurl $i 2>/dev/null`;
     my $result = join("", @out);
     chomp $result;
     if($result ne $o) {

--- a/trurl.c
+++ b/trurl.c
@@ -31,6 +31,10 @@
 
 #include "version.h"
 
+#ifdef _MSC_VER
+#define strncasecmp _strnicmp
+#endif
+
 #define OUTPUT_URL      0  /* default */
 #define OUTPUT_SCHEME   1
 #define OUTPUT_USER     2


### PR DESCRIPTION
Earlier I posted a few changes on mastodon to get trurl to build on windows with vc2022: https://mastodon.social/@krishean/110141578599204303

If you build curl as a static library (using native tools command prompt):
```
set "basedir=%cd%"
cd "curl-8.0.1\winbuild"
nmake /f Makefile.vc MODE=static WITH_PREFIX=%basedir%\builds\curl-win64 ENABLE_SCHANNEL=yes GEN_PDB=no DEBUG=no MACHINE=x64
cd "%basedir%"
```

And then build trurl with these changes like so:
```
git clone https://github.com/curl/trurl.git
cd trurl
cl /O2 /DNDEBUG /MD /DCURL_STATICLIB /I "%basedir%\builds\curl-win64\include" /W4 /DWIN32 trurl.c /link /LIBPATH:"%basedir%\builds\curl-win64\lib" /out:trurl.exe /subsystem:console /nologo /machine:x64 libcurl_a.lib ws2_32.lib wldap32.lib advapi32.lib crypt32.lib Normaliz.lib
perl test.pl
perl test-json.pl
```

It should only have a couple of compiler warnings and all tests should pass.