### PR TITLE
ignore bad urls when given a file of URLs

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -598,9 +598,14 @@ static void singleurl(struct option *o,
                      (o->accept_space ?
                       (CURLU_ALLOW_SPACE|CURLU_URLENCODE) : 0));
       if(rc) {
-        if(o->verify)
-          errorf(ERROR_BADURL, "%s [%s]", curl_url_strerror(rc), url);
-        warnf("%s [%s]", curl_url_strerror(rc), url);
+        if (o->url) { // check if we are reading from a file
+          return;
+        } 
+        else {
+          if(o->verify)
+            errorf(ERROR_BADURL, "%s [%s]", curl_url_strerror(rc), url);
+          warnf("%s [%s]", curl_url_strerror(rc), url);
+        }
       }
       else {
         if(o->redirect)


### PR DESCRIPTION
for #76 

I have developed this on windows 11.

the output is now:
`
PS C:\Users\Håvard\git\trurl> .\trurl.exe --url-file .\trurl\urls.txt
http://localhost/
http://haxx.se/
https://curl.se/
http://curl.haxx.se/
`

urls.txt:
`
PS C:\Users\Håvard\git\trurl> type .\trurl\urls.txt
localhost
haxx.se
ftp://ex ample.com
https://curl.se
curl.haxx.se
`
