### PR TITLE
trurl: add support for libcurl versions below 7.80.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 TARGET = trurl
 OBJS = trurl.o
 LDLIBS = -lcurl
-CFLAGS := $(CFLAGS) -W -Wall -pedantic -g \
-	-D LIBCURL_VERNUM="$(shell curl-config --vernum)"
-
+CFLAGS := $(CFLAGS) -W -Wall -pedantic -g
 MANUAL = trurl.1
 
 PREFIX ?= /usr/local

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 TARGET = trurl
 OBJS = trurl.o
 LDLIBS = -lcurl
-CFLAGS := $(CFLAGS) -W -Wall -pedantic -g
+CFLAGS := $(CFLAGS) -W -Wall -pedantic -g \
+	-D LIBCURL_VERNUM="$(shell curl-config --vernum)"
+
 MANUAL = trurl.1
 
 PREFIX ?= /usr/local

--- a/trurl.c
+++ b/trurl.c
@@ -51,7 +51,7 @@
 #define PROGNAME        "trurl"
 
 /* if libcurl < 7.80.0 */
-#if (defined(LIBCURL_VERNUM) && (LIBCURL_VERNUM < 0x075000))
+#if LIBCURL_VERSION_NUM < 0x075000
 #define CURLUE_NO_ZONEID 18
 #define CURLU_ALLOW_SPACE 0
 #define curl_url_strerror(error) \

--- a/trurl.c
+++ b/trurl.c
@@ -59,7 +59,7 @@
    here such that we may at least show the numeric value the user 
    may lookup */
 #define curl_url_strerror(error) \
-  "unsupported CURLUcode error"
+  fprintf(stderr, "URL error: %u\n", (int)error)
 #endif
 
 struct var {
@@ -340,7 +340,7 @@ static int getarg(struct option *op,
   else if(!strcmp("--accept-space", flag))
     if(!CURLU_ALLOW_SPACE) {
       warnf("%s","--accept-space is not supported in this version of libcurl");
-    }
+    } 
     else {
       op->accept_space = true;
     }

--- a/trurl.c
+++ b/trurl.c
@@ -54,8 +54,12 @@
 #if LIBCURL_VERSION_NUM < 0x075000
 #define CURLUE_NO_ZONEID 18
 #define CURLU_ALLOW_SPACE 0
+/* curl_url_strerror is not available below this version number, 
+   we need a safe way to convert CURLUcode into a const char*
+   here such that we may at least show the numeric value the user 
+   may lookup */
 #define curl_url_strerror(error) \
-  fprintf(stderr, "URL error: %s\n", curl_easy_strerror(error))
+  "unsupported CURLUcode error"
 #endif
 
 struct var {
@@ -334,7 +338,12 @@ static int getarg(struct option *op,
   else if(!strcmp("--verify", flag))
     op->verify = true;
   else if(!strcmp("--accept-space", flag))
-    op->accept_space = true;
+    if(!CURLU_ALLOW_SPACE) {
+      warnf("%s","--accept-space is not supported in this version of libcurl");
+    }
+    else {
+      op->accept_space = true;
+    }
   else if(!strcmp("--sort-query", flag))
     op->sort_query = true;
   else

--- a/trurl.c
+++ b/trurl.c
@@ -50,6 +50,14 @@
 
 #define PROGNAME        "trurl"
 
+/* if libcurl < 7.80.0 */
+#if (defined(LIBCURL_VERNUM) && (LIBCURL_VERNUM < 0x075000))
+#define CURLUE_NO_ZONEID 18
+#define CURLU_ALLOW_SPACE 0
+#define curl_url_strerror(error) \
+  fprintf(stderr, "URL error: %s\n", curl_easy_strerror(error))
+#endif
+
 struct var {
   const char *name;
   CURLUPart part;


### PR DESCRIPTION
This patch allows compiling with versions of libcurl as low as 7.68.0 (the latest available to Ubuntu 20.04 LTS #67). 

This approach gets us building, with okay test coverage but it should be better. @bagder I'm not great at C but happy to learn and contribute, could you advise on how the implementation may be improved?

### Tests
The test coverage fails 2 of 49.
```
not ok 28 - ./trurl --url https://10.1/we/are.html --get "{host}"
#   Failed test './trurl --url https://10.1/we/are.html --get "{host}"'
#   at ./test.pl line 66.
#          got: '10.1'
#     expected: '10.0.0.1'
not ok 29 - ./trurl --url https://[fe80::0000:20c:29ff:fe9c:409b]:8080/we/are.html --get "{host}"
#   Failed test './trurl --url https://[fe80::0000:20c:29ff:fe9c:409b]:8080/we/are.html --get "{host}"'
#   at ./test.pl line 66.
#          got: '[fe80::0000:20c:29ff:fe9c:409b]'
#     expected: '[fe80::20c:29ff:fe9c:409b]'
```

### Warns
```
trurl.c: In function ‘get’:
trurl.c:51:25: warning: format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘int’ [-Wformat=]
   51 | #define PROGNAME        "trurl"
      |                         ^~~~~~~
trurl.c:387:31: note: in expansion of macro ‘PROGNAME’
  387 |               fprintf(stderr, PROGNAME ": %s (%s)\n", curl_url_strerror(rc),
      |                               ^~~~~~~~
trurl.c:387:44: note: format string is defined here
  387 |               fprintf(stderr, PROGNAME ": %s (%s)\n", curl_url_strerror(rc),
      |                                           ~^
      |                                            |
      |                                            char *
      |                                           %d
trurl.c:383:13: warning: case value ‘18’ not in enumerated type ‘CURLUcode’ {aka ‘enum <anonymous>’} [-Wswitch]
  383 |             case CURLUE_NO_ZONEID:
      |             ^~~~
cc   trurl.o  -lcurl -o trurl
```