### PR TITLE
Valueless query vs trim (#80)

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -55,6 +55,9 @@ my @t = (
     "--accept-space --url \"gopher://localhost/ with space\"|gopher://localhost/%20with%20space",
     "--accept-space --url \"https://localhost/?with space\"|https://localhost/?with+space",
     "https://daniel\@curl.se:22/ -s port= -s user=|https://curl.se/",
+    "\"https://example.com?moo&search=hello\" --trim query=search|https://example.com/?moo",
+    "\"https://example.com?search=hello&moo\" --trim query=search|https://example.com/?moo",
+    "\"https://example.com?search=hello\" --trim query=search --append query=moo|https://example.com/?moo",
 );
 
 for my $c (@t) {

--- a/trurl.c
+++ b/trurl.c
@@ -546,7 +546,6 @@ static void trim(CURLU *uh, struct option *o)
         bool updated = 0;
         char *newq = q;
 
-        /* q is assumed to look like a=b&c=d&e=f */
         do {
           char *end = strchr(q, '&');
           char *sep = strchr(q, '=');


### PR DESCRIPTION
Per #80, `--trim()` will hang when other query string parameters (whether in the URL or added via `--append`) don't contain a value, and hence, no `=`

The same bad assumption (that all query parameters have a value) also leads us to fail to trim when the the parameter-to-be-queried doesn't have a value.

This fix separates the query string by `&` first, and then forgives those without an `=`