### PR TITLE
trurl: abort on a bad URL

### DIFF
--- a/trurl.1
+++ b/trurl.1
@@ -78,6 +78,9 @@ which then typically is not actually a legal URL but trurl will try to figure
 out what is meant and guess what scheme to use.
 
 Providing multiple URLs will make trurl act on all URLs in a serial fashion.
+
+If the URL cannot be parsed for whatever reason, trurl will simply move on to
+the next provided URL - unless \fI--verify\fP is used.
 .IP "--trim [component]=[what]"
 Trims data off a component. Currently this can only trim a query component.
 

--- a/trurl.c
+++ b/trurl.c
@@ -608,6 +608,7 @@ static void singleurl(struct option *o,
         if(o->verify)
           errorf(ERROR_BADURL, "%s [%s]", curl_url_strerror(rc), url);
         warnf("%s [%s]", curl_url_strerror(rc), url);
+        return;
       }
       else {
         if(o->redirect)


### PR DESCRIPTION
Slight change of behavior: if a URL is provided that cannot be parsed, it will now abort the operation for that URL and move on to the next URL instead. It makes for more consistent and dependable behavior.

Adding --verify to the mix will make trurl abort and exit with an error for the first non-parseable URL.

This probably replaces #84 and also fixes #76.