### PR TITLE
add --sort-query

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -68,6 +68,7 @@ my @t = (
     "ftp://hello:443/foo -s scheme=https|https://hello/foo",
     "\"https://example.com?utm_source=tra%20cker&address%20=home&here=now&thisthen\" -g {query:utm_source}|tra cker",
     "\"https://example.com?utm_source=tra%20cker&address%20=home&here=now&thisthen\" -g {:query:utm_source}|tra%20cker",
+    "\"https://example.com?utm_source=tracker&monkey=123\" --sort-query|https://example.com/?monkey=123&utm_source=tracker",
 );
 
 my %json_tests = (

--- a/trurl.1
+++ b/trurl.1
@@ -77,6 +77,10 @@ options, host, port, path, query, fragment and zoneid.
 If a simple "="-assignment is used, the data is URL encoded when applied. If
 ":=" is used, the data is assumed to already be URL encoded and will be stored
 as-is.
+.IP "--sort-query"
+The variable=content tuplets in the query component are sorted in a case
+insensitive alphabetical order. This helps making URLs identical that
+otherwise only had their query pairs in a different orders.
 .IP "--url [URL]"
 Set the input URL to work with. The URL may be provided without a scheme,
 which then typically is not actually a legal URL but trurl will try to figure


### PR DESCRIPTION
Sorts the query pairs in a case insensitive alphabetical order

Added a test. Added to the man page.

Ref: #88