### PR TITLE
add --query-separator

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -82,6 +82,8 @@ my @t = (
     "--url https://EXAMPLE.com|https://EXAMPLE.com/",
     "--url https://example.com/FOO/BAR|https://example.com/FOO/BAR",
     "--url [2001:0db8:0000:0000:0000:ff00:0042:8329]|http://[2001:db8::ff00:42:8329]/",
+    "\"https://example.com?utm=tra%20cker:address%20=home:here=now:thisthen\" --sort-query --query-separator \":\"|https://example.com/?address%20=home:here=now:thisthen:utm=tra%20cker",
+    "\"foo?a=bCd=eCe=f\" --query-separator C --trim query=d|http://foo/?a=bCe=f",
 );
 
 my %json_tests = (

--- a/trurl.1
+++ b/trurl.1
@@ -71,6 +71,12 @@ Show the help output.
 Outputs all set components of the URLs as JSON objects. All components of the
 URL that has data will get populated in the object using their component
 names.
+.IP "--query-separator [what]"
+Specify the single letter used for separating query pairs. The default is "&"
+but at least in the past sometimes semicolons ";" or even colons ":" have been
+used for this purpose. If your URL uses something other than the default
+letter, setting the right one makes sure trurl can do its query operations
+properly.
 .IP "--redirect [URL]"
 Redirect the URL to this new location. It requires that you set the base url
 with \fB--url\fP

--- a/trurl.c
+++ b/trurl.c
@@ -339,7 +339,7 @@ static int getarg(struct option *op,
   else if(checkoptarg("--query-separator", flag, arg)) {
     if(op->qsep)
       errorf(ERROR_FLAG, "only one --query-separator is supported");
-    if(strlen(arg) > 1)
+    if(strlen(arg) != 1)
       errorf(ERROR_FLAG, "only single-letter query separators are supported");
     op->qsep = arg;
     *usedarg = 1;

--- a/trurl.c
+++ b/trurl.c
@@ -141,6 +141,7 @@ static void help(void)
           "  -g, --get [{component}s]     - output component(s)\n"
           "  -h, --help                   - this help\n"
           "  --json                       - output URL as JSON\n"
+          "  --query-separator [letter]   - if something else than '&'\n"
           "  --redirect [URL]             - redirect to this\n"
           "  -s, --set [component]=[data] - set component content\n"
           "  --sort-query                 - alpha-sort the query pairs\n"
@@ -173,6 +174,7 @@ struct option {
   struct curl_slist *set_list;
   struct curl_slist *trim_list;
   const char *redirect;
+  const char *qsep;
   const char *format;
   FILE *url;
   bool urlopen;
@@ -332,6 +334,14 @@ static int getarg(struct option *op,
     if(op->redirect)
       errorf(ERROR_FLAG, "only one --redirect is supported");
     op->redirect = arg;
+    *usedarg = 1;
+  }
+  else if(checkoptarg("--query-separator", flag, arg)) {
+    if(op->qsep)
+      errorf(ERROR_FLAG, "only one --query-separator is supported");
+    if(strlen(arg) > 1)
+      errorf(ERROR_FLAG, "only single-letter query separators are supported");
+    op->qsep = arg;
     *usedarg = 1;
   }
   else if(checkoptarg("--trim", flag, arg)) {
@@ -730,7 +740,7 @@ static char *addqpair(char *pair, size_t len)
 }
 
 /* convert the query string into an array of name=data pair */
-static void extractqpairs(CURLU *uh)
+static void extractqpairs(CURLU *uh, struct option *o)
 {
   char *q = NULL;
   memset(qpairs, 0, sizeof(qpairs));
@@ -741,7 +751,7 @@ static void extractqpairs(CURLU *uh)
     char *amp;
     while(*p) {
       size_t len;
-      amp = strchr(p, '&');
+      amp = strchr(p, o->qsep[0]);
       if(!amp)
         len = strlen(p);
       else
@@ -756,14 +766,14 @@ static void extractqpairs(CURLU *uh)
   curl_free(q);
 }
 
-static void qpair2query(CURLU *uh)
+static void qpair2query(CURLU *uh, struct option *o)
 {
   int i;
   int rc;
   char *nq=NULL;
   for(i=0; i<nqpairs; i++) {
     nq = curl_maprintf("%s%s%s", nq?nq:"",
-                       (nq && *nq && *qpairs[i])? "&": "", qpairs[i]);
+                       (nq && *nq && *qpairs[i])? o->qsep: "", qpairs[i]);
   }
   if(nq) {
     rc = curl_url_set(uh, CURLUPART_QUERY, nq, 0);
@@ -842,7 +852,7 @@ static void singleurl(struct option *o,
       curl_free(opath);
     }
 
-    extractqpairs(uh);
+    extractqpairs(uh, o);
 
     /* append query segments */
     for(p = o->append_query; p; p=p->next) {
@@ -855,7 +865,7 @@ static void singleurl(struct option *o,
     sortquery(o);
 
     /* put the query back */
-    qpair2query(uh);
+    qpair2query(uh, o);
 
     if(o->jsonout)
       json(o, uh);
@@ -908,6 +918,8 @@ int main(int argc, const char **argv)
       argv++;
     }
   }
+  if(!o.qsep)
+    o.qsep = "&";
 
   if(o.jsonout)
     fputs("[\n", stdout);


### PR DESCRIPTION
Lets trurl work on queries that use something else than "&" as pair separator.