### PR TITLE
Properly free memory from libcurl functions

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -225,7 +225,7 @@ static void pathadd(struct option *o, const char *path)
   struct curl_slist *n;
   char *urle = curl_easy_escape(NULL, path, 0);
   if(urle) {
-    n = curl_slist_append(o->append_path, strdup(urle));
+    n = curl_slist_append(o->append_path, urle);
     if(n) {
       o->append_path = n;
     }
@@ -249,7 +249,7 @@ static void queryadd(struct option *o, const char *query)
   else
     urle = curl_easy_escape(NULL, query, 0);
   if(urle) {
-    n = curl_slist_append(o->append_query, strdup(urle));
+    n = curl_slist_append(o->append_query, urle);
     if(n) {
       o->append_query = n;
     }

--- a/trurl.c
+++ b/trurl.c
@@ -225,11 +225,11 @@ static void pathadd(struct option *o, const char *path)
   struct curl_slist *n;
   char *urle = curl_easy_escape(NULL, path, 0);
   if(urle) {
-    n = curl_slist_append(o->append_path, urle);
+    n = curl_slist_append(o->append_path, strdup(urle));
     if(n) {
       o->append_path = n;
     }
-    free(urle);
+    curl_free(urle);
   }
 }
 
@@ -249,11 +249,11 @@ static void queryadd(struct option *o, const char *query)
   else
     urle = curl_easy_escape(NULL, query, 0);
   if(urle) {
-    n = curl_slist_append(o->append_query, urle);
+    n = curl_slist_append(o->append_query, strdup(urle));
     if(n) {
       o->append_query = n;
     }
-    free(urle);
+    curl_free(urle);
   }
 }
 
@@ -693,6 +693,7 @@ static char *memdupdec(char *source, size_t len)
   char *sep = memchr(source, '=', len);
   char *left = NULL;
   char *right = NULL;
+  char *str, *dup;
   int leftlen = 0;
   int rightlen = 0;
 
@@ -702,9 +703,14 @@ static char *memdupdec(char *source, size_t len)
     right = curl_easy_unescape(NULL, sep + 1 , len - (sep - source) - 1,
                                &rightlen);
 
-  return curl_maprintf("%.*s%s%.*s", leftlen, left,
-                       right ? "=":"",
-                       rightlen, right?right:"");
+  str = curl_maprintf("%.*s%s%.*s", leftlen, left,
+                      right ? "=":"",
+                      rightlen, right?right:"");
+  curl_free(right);
+  curl_free(left);
+  dup = strdup(str);
+  curl_free(str);
+  return dup;
 }
 
 
@@ -771,9 +777,12 @@ static void qpair2query(CURLU *uh, struct option *o)
   int i;
   int rc;
   char *nq=NULL;
+  char *oldnq;
   for(i=0; i<nqpairs; i++) {
+    oldnq = nq;
     nq = curl_maprintf("%s%s%s", nq?nq:"",
                        (nq && *nq && *qpairs[i])? o->qsep: "", qpairs[i]);
+    curl_free(oldnq);
   }
   if(nq) {
     rc = curl_url_set(uh, CURLUPART_QUERY, nq, 0);


### PR DESCRIPTION
These pointers must be freed with curl_free, not free. Also, free some
memory that leaked otherwise. The test suite now passes with valgrind.