### PR TITLE
Free memory in JSON output & enable the clang address sanitizer

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,12 +14,12 @@ jobs:
       matrix:
         build:
         - name: default
-        - name: clang UBSAN
+        - name: clang sanitizers
           install_packages: clang
           make_opts: >
             CC=clang
-            CFLAGS="-fsanitize=undefined,signed-integer-overflow -Wformat -Werror=format-security -Werror=array-bounds -g"
-            LDFLAGS="-fsanitize=undefined,signed-integer-overflow -g"
+            CFLAGS="-fsanitize=address,undefined,signed-integer-overflow -Wformat -Werror=format-security -Werror=array-bounds -g"
+            LDFLAGS="-fsanitize=address,undefined,signed-integer-overflow -g"
 
     steps:
     - uses: actions/checkout@v3

--- a/trurl.c
+++ b/trurl.c
@@ -616,6 +616,7 @@ static void json(struct option *o, CURLU *uh)
         fputs(",\n", stdout);
       printf("    \"%s\": ", variables[i].name);
       jsonString(stdout, nurl, 0, false);
+      curl_free(nurl);
     }
   }
   if(nqpairs) {


### PR DESCRIPTION
This sanitizer now passes the test suite.