### PR TITLE
trurl: make '{scheme}\{user}' work

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -424,6 +424,7 @@ static void get(struct option *op, CURLU *uh)
         ptr++; /* pass the { */
         if(!end) {
           /* syntax error */
+          fputc('{', stream);
           continue;
         }
         /* {path} {:path} */

--- a/trurl.c
+++ b/trurl.c
@@ -494,10 +494,10 @@ static void get(struct option *op, CURLU *uh)
         fputc('\\', stream);
         break;
       default:
-        /* unknown, just output this */
+        /* unknown, just output the backslash, and continue */
         fputc(*ptr, stream);
-        fputc(ptr[1], stream);
-        break;
+        ptr++;
+        continue;
       }
       ptr += 2;
     }

--- a/trurl.c
+++ b/trurl.c
@@ -490,6 +490,9 @@ static void get(struct option *op, CURLU *uh)
       case 't':
         fputc('\t', stream);
         break;
+      case '\\':
+        fputc('\\', stream);
+        break;
       default:
         /* unknown, just output this */
         fputc(*ptr, stream);


### PR DESCRIPTION
trurl: support \\\\ in -g formats

This allows e.g. printing 'imap\\new' with  -g '{host}\\\\new'.
It was previously not possible to print a literal backslash followed by
a n/t/r with -g.

---

trurl: make '{scheme}\\{user}' work

Before this patch, the sequence \`\\{' was handled by printing a literal
backslash followed by a literal {.

This was a bit awkward since you are supposed to be using \`{{' to escape
a { character, not \\. Also because the backslash was still being
printed.

With this patch \`\\{' is now handled by only printing a backslash, and
then handling the next character, instead of printing it
indiscrimintately.

So, now,   trurl -g '{scheme}\\{user}' gopher://emanuele6@locahost/
outputs   gopher\\emanuele6   instead of   gopher\\{user}   .

The previous commit that added support for \`\\\\' makes this change less
necessary since the user should have used   {scheme}\\\\{user}   instead
of using a single backslash, but I still think this behaviour makes more
sense, and may prevent future bugs.
