### PR TITLE
support --get variables within [brackets]

### DIFF
--- a/trurl.1
+++ b/trurl.1
@@ -48,11 +48,13 @@ Each line needs to be a single valid URL and the line needs to end with a
 newline. The maximum URL length supported in a file like this is 4095 bytes.
 .IP "-g, --get [format]"
 Output URL data according to the provided format string. Components from the
-URL can be output when specified as \fB{component}\fP, with the name of the
-part show within curly braces. The following component names are available
-(case sensitive): {url}, {scheme}, {user}, {password}, {options}, {host},
-{port}, {path}, {query}, {fragment} and {zoneid}. All other text in the format
-string will be shown as-is.
+URL can be output when specified as \fB{component}\fP or \fB[component]\fP,
+with the name of the part show within curly braces or brackets. You can not
+mix braces and brackets for this purpose in the same command line.
+
+The following component names are available (case sensitive): url, scheme,
+user, password, options, host, port, path, query, fragment and zoneid. All
+other text in the format string will be shown as-is.
 
 Components are shown URL decoded by default. If you instead write the
 component prefixed with a colon like "{:path}", it gets output URL encoded.
@@ -65,6 +67,20 @@ as four dot-separated decimal numbers when output.
 
 You can access specific keys in the query string using the format
 \fB{query:key}\fP. Then the value of the first matching key will be output.
+
+The "format" string supports the following backslash sequences:
+
+\&\\\\ - backslash
+
+\&\\t - tab
+
+\&\\n - newline
+
+\&\\r - carriage return
+
+\&\\{ - an open curly brace that does not start a variable
+
+\&\\[ - an open bracket that does not start a variable
 .IP "-h, --help"
 Show the help output.
 .IP "--json"

--- a/trurl.1
+++ b/trurl.1
@@ -47,14 +47,14 @@ minus) to tell trurl to read the URLs from stdin.
 Each line needs to be a single valid URL and the line needs to end with a
 newline. The maximum URL length supported in a file like this is 4095 bytes.
 .IP "-g, --get [format]"
-Output URL data according to the provided format string. Components from the
-URL can be output when specified as \fB{component}\fP or \fB[component]\fP,
-with the name of the part show within curly braces or brackets. You can not
-mix braces and brackets for this purpose in the same command line.
+Output text and URL data according to the provided format string. Components
+from the URL can be output when specified as \fB{component}\fP or
+\fB[component]\fP, with the name of the part show within curly braces or
+brackets. You can not mix braces and brackets for this purpose in the same
+command line.
 
 The following component names are available (case sensitive): url, scheme,
-user, password, options, host, port, path, query, fragment and zoneid. All
-other text in the format string will be shown as-is.
+user, password, options, host, port, path, query, fragment and zoneid.
 
 Components are shown URL decoded by default. If you instead write the
 component prefixed with a colon like "{:path}", it gets output URL encoded.
@@ -81,6 +81,8 @@ The "format" string supports the following backslash sequences:
 \&\\{ - an open curly brace that does not start a variable
 
 \&\\[ - an open bracket that does not start a variable
+
+All other text in the format string will be shown as-is.
 .IP "-h, --help"
 Show the help output.
 .IP "--json"

--- a/trurl.c
+++ b/trurl.c
@@ -433,6 +433,7 @@ static void get(struct option *op, CURLU *uh)
         ptr++; /* pass the { */
         if(!end) {
           /* syntax error */
+          fputc(startbyte, stream);
           continue;
         }
         /* {path} {:path} */

--- a/trurl.c
+++ b/trurl.c
@@ -405,12 +405,21 @@ static void get(struct option *op, CURLU *uh)
   FILE *stream = stdout;
   const char *ptr = op->format;
   bool done = false;
+  char startbyte = 0;
+  char endbyte = 0;
 
   while(ptr && *ptr && !done) {
-    if('{' == *ptr) {
-      if('{' == ptr[1]) {
+    if(!startbyte && (('{' == *ptr) || ('[' == *ptr))) {
+      startbyte = *ptr;
+      if('{' == *ptr)
+        endbyte = '}';
+      else
+        endbyte = ']';
+    }
+    if(startbyte == *ptr) {
+      if(startbyte == ptr[1]) {
         /* an escaped {-letter */
-        fputc('{', stream);
+        fputc(startbyte, stream);
         ptr += 2;
       }
       else {
@@ -420,7 +429,7 @@ static void get(struct option *op, CURLU *uh)
         size_t vlen;
         int i;
         bool urldecode = true;
-        end = strchr(ptr, '}');
+        end = strchr(ptr, endbyte);
         ptr++; /* pass the { */
         if(!end) {
           /* syntax error */
@@ -489,6 +498,15 @@ static void get(struct option *op, CURLU *uh)
         break;
       case 't':
         fputc('\t', stream);
+        break;
+      case '\\':
+        fputc('\\', stream);
+        break;
+      case '{':
+        fputc('{', stream);
+        break;
+      case '[':
+        fputc('[', stream);
         break;
       default:
         /* unknown, just output this */


### PR DESCRIPTION
also extend the backslash support somewhat and document it.