### PR TITLE
Fix test.pl on windows

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -88,7 +88,7 @@ my @t = (
     "localhost -g \"[scheme] [host\"|http [host",
     # two backslashes in the source end up one in the actual command line
     "localhost -g \"\\{{scheme}\\[\"|{http[",
-    "localhost -g \"\\\\\[\"|\\[",
+    "localhost -g " . (($^O eq 'MSWin32')?"\"\\\\\[\"":"'\\\\\['") . "|\\[",
     "https://u:s\@foo?moo -g \"[scheme][user][password][query]\"|httpsusmoo",
 );
 

--- a/test.pl
+++ b/test.pl
@@ -169,21 +169,23 @@ my %json_tests = (
 
 plan tests => keys(@t) + keys(%json_tests);
 
+my ( $cmd_string, $null_device ) = ($^O eq 'MSWin32')?(".\\trurl.exe", "nul"):("./trurl", "/dev/null");
+
 for my $c (@t) {
     my ($i, $o) = split(/\|/, $c);
     # A future version should also check stderr
-    my @out = ($^O eq 'MSWin32')?`.\\trurl.exe $i 2>nul`:`./trurl $i 2>/dev/null`;
+    my @out = `$cmd_string $i 2>$null_device`;
     my $result = join("", @out);
     chomp $result;
-    is( $result, $o, "./trurl $i" );
+    is( $result, $o, "$cmd_string $i" );
 }
 
 while (my($i, $o) = each %json_tests) {
-    my @out = ($^O eq 'MSWin32')?`.\\trurl.exe --json $i 2>nul`:`./trurl --json $i 2>/dev/null`;
+    my @out = `$cmd_string --json $i 2>$null_device`;
     my $result_json = join("", @out);
     my $result = decode_json($result_json);
 
-    is_deeply($result, $o, "./trurl --json $i");
+    is_deeply($result, $o, "$cmd_string --json $i");
 }
 
 done_testing();

--- a/test.pl
+++ b/test.pl
@@ -87,7 +87,7 @@ my @t = (
     "localhost -g \"{scheme} {host\"|http {host",
     "localhost -g \"[scheme] [host\"|http [host",
     # two backslashes in the source end up one in the actual command line
-    "localhost -g \"\\{{scheme}\\[\"|{http[",
+    "localhost -g " . (($^O eq 'MSWin32')?"\"\\{{scheme}\\[\"":"'\\{{scheme}\\['") . "|{http[",
     "localhost -g " . (($^O eq 'MSWin32')?"\"\\\\\[\"":"'\\\\\['") . "|\\[",
     "https://u:s\@foo?moo -g \"[scheme][user][password][query]\"|httpsusmoo",
 );

--- a/test.pl
+++ b/test.pl
@@ -12,7 +12,7 @@ my @t = (
     "http://example.com|http://example.com/",
     "https://example.com|https://example.com/",
     "hp://example.com|hp://example.com/",
-    "|",
+    "|trurl error: not enough input for a URL\ntrurl error: Try trurl -h for help",
     "ftp.example.com|ftp://ftp.example.com/",
     "https://example.com/../moo|https://example.com/moo",
     "https://example.com/.././moo|https://example.com/moo",
@@ -167,21 +167,22 @@ my %json_tests = (
     ]
 );
 
-plan tests => keys(@t) + keys(%json_tests);
+my $cmd_string = ($^O eq 'MSWin32')?".\\trurl.exe":"./trurl";
 
-my ( $cmd_string, $null_device ) = ($^O eq 'MSWin32')?(".\\trurl.exe", "nul"):("./trurl", "/dev/null");
+plan tests => keys(@t) + keys(%json_tests);
 
 for my $c (@t) {
     my ($i, $o) = split(/\|/, $c);
-    # A future version should also check stderr
-    my @out = `$cmd_string $i 2>$null_device`;
+    # "2>&1" at the end of the parameters redirects stderr to stdin
+    # to check both output streams against the expected value
+    my @out = `$cmd_string $i 2>&1`;
     my $result = join("", @out);
     chomp $result;
     is( $result, $o, "$cmd_string $i" );
 }
 
 while (my($i, $o) = each %json_tests) {
-    my @out = `$cmd_string --json $i 2>$null_device`;
+    my @out = `$cmd_string --json $i 2>&1`;
     my $result_json = join("", @out);
     my $result = decode_json($result_json);
 

--- a/test.pl
+++ b/test.pl
@@ -84,12 +84,12 @@ my @t = (
     "--url [2001:0db8:0000:0000:0000:ff00:0042:8329]|http://[2001:db8::ff00:42:8329]/",
     "\"https://example.com?utm=tra%20cker:address%20=home:here=now:thisthen\" --sort-query --query-separator \":\"|https://example.com/?address%20=home:here=now:thisthen:utm=tra%20cker",
     "\"foo?a=bCd=eCe=f\" --query-separator C --trim query=d|http://foo/?a=bCe=f",
-    "localhost -g '{scheme} {host'|http {host",
-    "localhost -g '[scheme] [host'|http [host",
+    "localhost -g \"{scheme} {host\"|http {host",
+    "localhost -g \"[scheme] [host\"|http [host",
     # two backslashes in the source end up one in the actual command line
-    "localhost -g '\\{{scheme}\\['|{http[",
-    "localhost -g '\\\\\['|\\[",
-    "https://u:s\@foo?moo -g '[scheme][user][password][query]'|httpsusmoo",
+    "localhost -g \"\\{{scheme}\\[\"|{http[",
+    "localhost -g \"\\\\\[\"|\\[",
+    "https://u:s\@foo?moo -g \"[scheme][user][password][query]\"|httpsusmoo",
 );
 
 my %json_tests = (


### PR DESCRIPTION
Windows doesn't like single quotes in commands, it causes those tests to fail (the others still pass.)

Changing single quotes to escaped double quotes makes all the tests pass again.