### PR TITLE
support reading URL from a file without a newline

### DIFF
--- a/trurl.1
+++ b/trurl.1
@@ -44,8 +44,9 @@ provides a best-effort to convert the provided string into a valid URL.
 Read URLs to work on from the given file. Use the file name "-" (a single
 minus) to tell trurl to read the URLs from stdin.
 
-Each line needs to be a single valid URL and the line needs to end with a
-newline. The maximum URL length supported in a file like this is 4095 bytes.
+Each line needs to be a single valid URL - but trurl will trim off any
+trailing spaces and tabs from the end of the line. The maximum URL length
+supported in a file like this is 4095 bytes.
 .IP "-g, --get [format]"
 Output text and URL data according to the provided format string. Components
 from the URL can be output when specified as \fB{component}\fP or

--- a/trurl.c
+++ b/trurl.c
@@ -972,11 +972,25 @@ int main(int argc, const char **argv)
         if(eol[-1] == '\r')
           /* CRLF detected */
           eol--;
+      }
+      else if(feof(o.url))
+        /* end of file */
+        eol = strlen(buffer) + buffer;
+      else {
+        /* no newline but not end of file means that this line is truncated
+           and we are lost */
+        break;
+      }
+
+      /* trim trailing spaces and tabs */
+      while((eol > buffer) &&
+            ((eol[-1] == ' ') || eol[-1] == '\t'))
+        eol--;
+
+      if(eol > buffer) {
+        /* if ther is actual content left to deal with */
         *eol = 0; /* end of URL */
         singleurl(&o, buffer);
-      }
-      else {
-        /* no newline or no content, skip */
       }
     }
     if(o.urlopen)


### PR DESCRIPTION
... also trim off trailing whitespace from URLs provided from a file

Reported-by: @andylima
Fixes #137