### PR TITLE
--get {query-all:key} outputs all values for 'key' in the query

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -90,6 +90,7 @@ my @t = (
     "localhost -g '\\{{scheme}\\['|{http[",
     "localhost -g '\\\\\['|\\[",
     "https://u:s\@foo?moo -g '[scheme][user][password][query]'|httpsusmoo",
+    "\"hej?a=b&a=c&a=d&b=a\" -g '{query-all:a}'|b c d",
 );
 
 my %json_tests = (

--- a/tests.json
+++ b/tests.json
@@ -648,6 +648,14 @@
         }
     },
     {
+        "cmdline": "\"hej?a=b&a=c&a=d&b=a\" -g '{query-all:a}'",
+        "expected": {
+            "stderr": "",
+            "returncode": 0,
+            "stdout": "b c d"
+        }
+    },
+    {
         "cmdline": "\"https://example.com?utm=tra%20cker&address%20=home&here=now&thisthen\" --json",
         "expected": {
             "stderr": "",

--- a/trurl.1
+++ b/trurl.1
@@ -67,7 +67,12 @@ Hosts provided as IPv4 numerical addresses will be "normalized" and provided
 as four dot-separated decimal numbers when output.
 
 You can access specific keys in the query string using the format
-\fB{query:key}\fP. Then the value of the first matching key will be output.
+\fB{query:key}\fP. Then the value of the first matching key will be output
+using a case sensitive match.
+
+You can access specific keys in the query string and out all values using the
+format \fB{query-all:key}\fP. This looks for 'key' case sensitively and will
+output all values for that key space-separated.
 
 The "format" string supports the following backslash sequences:
 

--- a/trurl.c
+++ b/trurl.c
@@ -379,32 +379,22 @@ static int getarg(struct option *op,
   return 0;
 }
 
-static void showqkey(const char *key, size_t klen, bool urldecode, bool showall)
+static void showqkey(const char *key, size_t klen, bool urldecode,
+                     bool showall)
 {
   int i;
   bool shown = false;
+  char **qp = urldecode ? qpairsdec : qpairs;
+
   for(i = 0; i< nqpairs; i++) {
-    if(urldecode) {
-      if(!strncmp(key, qpairsdec[i], klen) &&
-         (qpairsdec[i][klen] == '=')) {
-        if(shown)
-          fputc(' ', stdout);
-        fputs(&qpairsdec[i][klen + 1], stdout);
-        if(!showall)
-          break;
-        shown = true;
-      }
-    }
-    else {
-      if(!strncmp(key, qpairs[i], klen) &&
-         (qpairs[i][klen] == '=')) {
-        if(shown)
-          fputc(' ', stdout);
-        fputs(&qpairs[i][klen + 1], stdout);
-        if(!showall)
-          break;
-        shown = true;
-      }
+    if(!strncmp(key, qp[i], klen) &&
+       (qp[i][klen] == '=')) {
+      if(shown)
+        fputc(' ', stdout);
+      fputs(&qp[i][klen + 1], stdout);
+      if(!showall)
+        break;
+      shown = true;
     }
   }
 }

--- a/trurl.c
+++ b/trurl.c
@@ -379,22 +379,31 @@ static int getarg(struct option *op,
   return 0;
 }
 
-static void showqkey(const char *key, size_t klen, bool urldecode)
+static void showqkey(const char *key, size_t klen, bool urldecode, bool showall)
 {
   int i;
+  bool shown = false;
   for(i = 0; i< nqpairs; i++) {
     if(urldecode) {
       if(!strncmp(key, qpairsdec[i], klen) &&
          (qpairsdec[i][klen] == '=')) {
+        if(shown)
+          fputc(' ', stdout);
         fputs(&qpairsdec[i][klen + 1], stdout);
-        break;
+        if(!showall)
+          break;
+        shown = true;
       }
     }
     else {
       if(!strncmp(key, qpairs[i], klen) &&
          (qpairs[i][klen] == '=')) {
+        if(shown)
+          fputc(' ', stdout);
         fputs(&qpairs[i][klen + 1], stdout);
-        break;
+        if(!showall)
+          break;
+        shown = true;
       }
     }
   }
@@ -442,12 +451,14 @@ static void get(struct option *op, CURLU *uh)
           ptr++;
         }
         vlen = end - ptr;
-        /* check for a colon within here */
+        /* check for the last colon within here */
         cl = memchr(ptr, ':', vlen);
         if(cl) {
           /* deduct the colon part */
-          if(!strncmp(ptr, "query:", 6))
-            showqkey(&ptr[6], end - cl - 1, urldecode);
+          if(!strncmp(ptr, "query-all:", 10))
+            showqkey(&ptr[10], end - cl - 1, urldecode, true);
+          else if(!strncmp(ptr, "query:", 6))
+            showqkey(&ptr[6], end - cl - 1, urldecode, false);
           else
             errorf(ERROR_GET, "Bad --get syntax: %s", ptr);
         }


### PR DESCRIPTION
Includes docs and test.

Fixes #128