### PR TITLE
bmake-compatible makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ MANDIR ?= $(DESTDIR)$(PREFIX)/share/man/man1
 INSTALL = install
 
 $(TARGET): $(OBJS)
-	$(CC) $(CFLAGS) $(OBJS) -o $(TARGET) $(LDLIBS)
+	$(CC) $(OBJS) -o $(TARGET) $(LDLIBS)
 
 trurl.o:trurl.c version.h
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 TARGET = trurl
 OBJS = trurl.o
 LDLIBS != curl-config --libs
-CFLAGS := $(CFLAGS) -W -Wall -pedantic -g
+CFLAGS != curl-config --cflags
+CFLAGS += -W -Wall -pedantic -g
 MANUAL = trurl.1
 
 PREFIX ?= /usr/local

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ MANDIR ?= $(DESTDIR)$(PREFIX)/share/man/man1
 INSTALL = install
 
 $(TARGET): $(OBJS)
-	$(CC) $(OBJS) -o $(TARGET) $(LDLIBS)
+	$(CC) $(OBJS) -o $(TARGET) $(LDLIBS) $(LDFLAGS)
 
 trurl.o:trurl.c version.h
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TARGET = trurl
 OBJS = trurl.o
-LDLIBS = -lcurl
+LDLIBS != curl-config --libs
 CFLAGS := $(CFLAGS) -W -Wall -pedantic -g
 MANUAL = trurl.1
 
@@ -11,6 +11,7 @@ MANDIR ?= $(DESTDIR)$(PREFIX)/share/man/man1
 INSTALL = install
 
 $(TARGET): $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) -o $(TARGET) $(LDLIBS)
 
 trurl.o:trurl.c version.h
 


### PR DESCRIPTION
Uses a BSD extension (!=) which GNU Make seems to support. Allows me to remove the gmake dependency for the OpenBSD port (I could use a patch here, but I didn't see how this could hurt in upstream)