### PR TITLE
codespell

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -17,7 +17,7 @@ Bugfixes since previous release
  * flush stdout after handling every URL
  * mixing --json with --get is an error
  * more test cases
- * show error messsage when component setting fails
+ * show error message when component setting fails
  * support "--" end-of-options argument
  * support for building with older libcurl versions
  * checksrc: check code style in CI job and with 'make checksrc'

--- a/test.py
+++ b/test.py
@@ -115,7 +115,7 @@ def main():
 
     if len(sys.argv) > 1:
         if sys.argv[1][0].isnumeric():
-            # run only test cases sepereated by ","
+            # run only test cases separated by ","
             testIndexesToRun = []
 
             for caseIndex in sys.argv[1].split(","):

--- a/trurl.c
+++ b/trurl.c
@@ -876,7 +876,7 @@ static void singleurl(struct option *o,
       curl_url_get(uh, CURLUPART_PATH, &opath, 0);
 
       /* does the existing path end with a slash, then don't
-         add one inbetween */
+         add one in between */
       olen = strlen(opath);
 
       /* append the new segment */
@@ -988,7 +988,7 @@ int main(int argc, const char **argv)
         eol--;
 
       if(eol > buffer) {
-        /* if ther is actual content left to deal with */
+        /* if there is actual content left to deal with */
         *eol = 0; /* end of URL */
         singleurl(&o, buffer);
       }


### PR DESCRIPTION
i know its sort of annoying but in the process of getting trurl ready to be accepted into debian, codespell is one of the things that is executed and if it complains ..well.. just fix it :-)

Maybe it makes sense to integrate it in CI? Let me know :)