### PR TITLE
fix mandoc warning

### DIFF
--- a/trurl.1
+++ b/trurl.1
@@ -2,7 +2,7 @@
 .\" man -l trurl.1
 .\" Written by Daniel Stenberg
 .\"
-.TH trurl 1 "3 Apr 2023" "trurl 0.4" "trurl Manual"
+.TH trurl 1 "April 3, 2023" "trurl 0.4" "trurl Manual"
 .SH NAME
 trurl \- transpose URLs
 .SH SYNOPSIS


### PR DESCRIPTION
fix for:

mandoc -T lint -W warning trurl.1 
mandoc: trurl.1:5:13: WARNING: cannot parse date, using it verbatim: 3 Apr 2023
