### PR TITLE
Makefile: use .PHONY, and allow using a different python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,29 @@ PREFIX ?= /usr/local
 BINDIR ?= $(DESTDIR)$(PREFIX)/bin
 MANDIR ?= $(DESTDIR)$(PREFIX)/share/man/man1
 
-INSTALL = install
+INSTALL ?= install
+PYTHON3 ?= python3
 
 $(TARGET): $(OBJS)
 	$(CC) $(OBJS) -o $(TARGET) $(LDLIBS) $(LDFLAGS)
 
 trurl.o:trurl.c version.h
 
+.PHONY: install
 install:
 	$(INSTALL) -d $(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(BINDIR)
 	$(INSTALL) -d $(MANDIR)
 	$(INSTALL) -m 0644 $(MANUAL) $(MANDIR)
 
+.PHONY: clean
 clean:
 	rm -f $(OBJS) $(TARGET)
 
+.PHONY: test
 test:
-	@python3 test.py
+	@$(PYTHON3) test.py
 
+.PHONY: checksrc
 checksrc:
 	./checksrc.pl trurl.c version.h


### PR DESCRIPTION
Mark targets that do not generate a file with .PHONY.

Allow using a different PYTHON3 interpreter for systems that install python3 as python3.9 or similar like NetBSD.