### PR TITLE
Makefile: fix build with GNU Make 3.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 TARGET = trurl
 OBJS = trurl.o
-LDLIBS != curl-config --libs
-CFLAGS != curl-config --cflags
-CFLAGS += -W -Wall -pedantic -g
+LDLIBS = $$(curl-config --libs)
+CFLAGS = $$(curl-config --cflags) -W -Wall -pedantic -g
 MANUAL = trurl.1
 
 PREFIX ?= /usr/local


### PR DESCRIPTION
The `!=` operator is not supported by GNU Make 3.x, shipped by macOS.

An implication of this is that the `curl-config` result will not be stored. Given that there is currently only one `.c` source file, it shouldn't make much difference.

```console
$ bmake
cc  $(curl-config --cflags) -W -Wall -pedantic -g -c trurl.c -o trurl.o
cc trurl.o -o trurl $(curl-config --libs)
$ bmake clean
rm -f trurl.o trurl
$ gmake
cc $(curl-config --cflags) -W -Wall -pedantic -g   -c -o trurl.o trurl.c
cc trurl.o -o trurl $(curl-config --libs)
$ gmake clean
rm -f trurl.o trurl
```
