### PR TITLE
Respect CFLAGS, CPPFLAGS in Makefile, fix LDFLAGS order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ INSTALL ?= install
 PYTHON3 ?= python3
 
 $(TARGET): $(OBJS)
-	$(CC) $(OBJS) -o $(TARGET) $(LDLIBS) $(LDFLAGS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(OBJS) -o $(TARGET) $(LDLIBS)
 
 trurl.o:trurl.c version.h
 


### PR DESCRIPTION
The implicit rule handled this correctly but a7f9ca9c42c2cf29cc84becb38b56082898868d4 did away with that.

Add CPPFLAGS (for the C preprocessor) and CFLAGS explicitly, and then shift LDFLAGS earlier to be before the object list, which is needed for e.g. -Wl,--as-needed to work correctly.

Fixes: a7f9ca9c42c2cf29cc84becb38b56082898868d4