### PR TITLE
Output valid JSON when aborting with --verify and when the constructed URL is not valid.

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -1412,5 +1412,47 @@
                 }
             ]
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--json",
+                "-s",
+                "scheme=irc",
+                "-s",
+                "host=curl.se"
+            ]
+        },
+        "expected": {
+            "stdout": [
+                {
+                    "url": "irc://curl.se/",
+                    "scheme": "irc",
+                    "host": "curl.se",
+                    "path": "/"
+                }
+            ],
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--json",
+                "-s",
+                "host=curl.se"
+            ]
+        },
+        "expected": {
+            "stdout": [
+                {
+                    "host": "curl.se",
+                    "path": "/"
+                }
+            ],
+            "returncode": 0,
+            "stderr": ""
+        }
     }
 ]

--- a/tests.json
+++ b/tests.json
@@ -1454,5 +1454,29 @@
             "returncode": 0,
             "stderr": ""
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--verify",
+                "--json",
+                "ftp://example.org",
+                "",
+                "git://curl.se/"
+            ]
+        },
+        "expected": {
+            "stdout": [
+                {
+                    "url": "ftp://example.org/",
+                    "scheme": "ftp",
+                    "host": "example.org",
+                    "port": "21",
+                    "path": "/"
+                }
+            ],
+            "returncode": 9,
+            "stderr": "trurl error: No host part in the URL []\ntrurl error: Try trurl -h for help\n"
+        }
     }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -663,6 +663,7 @@ static void jsonString(FILE *stream, const char *in, size_t len,
 static void json(struct option *o, CURLU *uh)
 {
   int i;
+  bool first = true;
   (void)o;
   printf("%s  {\n", o->urls?",\n":"");
   for(i = 0; variables[i].name; i++) {
@@ -671,8 +672,9 @@ static void json(struct option *o, CURLU *uh)
                                 (i?CURLU_DEFAULT_PORT:0)|
                                 CURLU_URLDECODE);
     if(!rc) {
-      if(i)
+      if(!first)
         fputs(",\n", stdout);
+      first = false;
       printf("    \"%s\": ", variables[i].name);
       jsonString(stdout, nurl, 0, false);
       curl_free(nurl);

--- a/trurl.c
+++ b/trurl.c
@@ -134,6 +134,16 @@ static void errorf(int exit_code, char *fmt, ...)
   exit(exit_code);
 }
 
+#define VERIFY(op, exit_code, ...) \
+  do { \
+    if(op->verify) { \
+      /* make sure to terminate the JSON array */ \
+      if(op->jsonout) \
+        fputs("\n]\n", stdout); \
+      errorf(exit_code, __VA_ARGS__); \
+    } else \
+      warnf(__VA_ARGS__); \
+  } while(0)
 
 static void help(void)
 {
@@ -906,9 +916,7 @@ static void singleurl(struct option *o,
                      (o->accept_space ?
                       (CURLU_ALLOW_SPACE|CURLU_URLENCODE) : 0));
       if(rc) {
-        if(o->verify)
-          errorf(ERROR_BADURL, "%s [%s]", curl_url_strerror(rc), url);
-        warnf("%s [%s]", curl_url_strerror(rc), url);
+        VERIFY(o, ERROR_BADURL, "%s [%s]", curl_url_strerror(rc), url);
         return;
       }
       else {


### PR DESCRIPTION
trurl: json: print comma only after printing the first valid component

This fixes  trurl --json  outputting invalid JSON when not enough components are provided with --set.

Examples:
$ trurl --json
* Before:
  ```json
    [
      {
    ,
        "path": "/"
      }
    ]
  ```
* Now:
  ```json
  [
    {
      "path": "/"
    }
  ]
  ```
$ trurl --json -s host=hi
* Before:
  ```json
    [
      {
    ,
        "host": "hi",
        "path": "/"
      }
    ]
  ```
* Now:
  ```json
    [
      {
        "host": "hi",
        "path": "/"
      }
    ]
  ```

---
trurl: make sure to terminate the JSON array when aborting with --verify
