### PR TITLE
Make sure modified URLs are valid before printing them

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -1445,14 +1445,9 @@
             ]
         },
         "expected": {
-            "stdout": [
-                {
-                    "host": "curl.se",
-                    "path": "/"
-                }
-            ],
-            "returncode": 0,
-            "stderr": ""
+            "stdout": [],
+            "returncode": 7,
+            "stderr": "trurl error: not enough input for a URL\ntrurl error: Try trurl -h for help\n"
         }
     },
     {

--- a/tests.json
+++ b/tests.json
@@ -1473,5 +1473,18 @@
             "returncode": 9,
             "stderr": "trurl error: No host part in the URL []\ntrurl error: Try trurl -h for help\n"
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "scheme=imap"
+            ]
+        },
+        "expected": {
+            "stdout": "",
+            "returncode": 7,
+            "stderr": "trurl error: not enough input for a URL\ntrurl error: Try trurl -h for help\n"
+        }
     }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -1178,6 +1178,7 @@ int main(int argc, const char **argv)
       else {
         struct iterinfo iinfo;
         memset(&iinfo, 0, sizeof(iinfo));
+        o.verify = true;
         singleurl(&o, NULL, &iinfo, o.iter_list);
       }
     } while(node);

--- a/trurl.c
+++ b/trurl.c
@@ -899,6 +899,16 @@ static void sortquery(struct option *o)
   }
 }
 
+static CURLUcode urlfromstring(struct option *o,
+                               CURLU *uh,
+                               const char *url)
+{
+  return curl_url_set(uh, CURLUPART_URL, url,
+                      CURLU_GUESS_SCHEME|CURLU_NON_SUPPORT_SCHEME|
+                      (o->accept_space ?
+                       (CURLU_ALLOW_SPACE|CURLU_URLENCODE) : 0));
+}
+
 static void singleurl(struct option *o,
                       const char *url, /* might be NULL */
                       struct iterinfo *iinfo,
@@ -910,11 +920,7 @@ static void singleurl(struct option *o,
     if(!uh)
       errorf(ERROR_MEM, "out of memory");
     if(url) {
-      CURLUcode rc =
-        curl_url_set(uh, CURLUPART_URL, url,
-                     CURLU_GUESS_SCHEME|CURLU_NON_SUPPORT_SCHEME|
-                     (o->accept_space ?
-                      (CURLU_ALLOW_SPACE|CURLU_URLENCODE) : 0));
+      CURLUcode rc = urlfromstring(o, uh, url);
       if(rc) {
         VERIFY(o, ERROR_BADURL, "%s [%s]", curl_url_strerror(rc), url);
         return;


### PR DESCRIPTION
Currently trurl can output invalid URLs because `curl_url_get(CURLUPART_URL)` doesn't necessarily generate a valid URL if `curl_url_set()` is used on the URL handle.

A user could filter invalid URLs using another trurl process like `trurl -f file.txt -s 'scheme=s://' | trurl -f -`, but this is not great, especially if the user is using `--json`.

This patch tries to fix that; I'm not sure this is the best approach to fix this, but it at least, works in preventing trurl from outputting invalid URLs. Maybe there are better approaches.

Just like before, it is still possible to modify the meaning of the URL by setting invalid parts, but now at least the output of `--json` will be correct, e.g.:
```bash
$ trurl https://localhost -s 'scheme=s://example.org/'
s://example.org/://localhost/
$ ./trurl --json https://localhost -s 'scheme=s://example.org/'
[
  {
    "url": "s://example.org/://localhost/",
    "scheme": "s",
    "host": "example.org",
    "path": "/://localhost/"
  }
]
$ ./old_trurl https://localhost -s 'scheme=s://example.org/'
s://example.org/://localhost/
$ ./old_trurl --json https://localhost -s 'scheme=s://example.org/'
[
  {
    "url": "s://example.org/://localhost/",
    "scheme": "s://example.org/",
    "host": "localhost",
    "path": "/"
  }
]
```

Maybe, instead simply `strcmp()`ing the URL string of the reparsed URL against the old one, in order to prevent changing other parts of the URL by setting other parts to invalid values, we should loop the set list, and try to get every component that is in the set list from the reparsed URL, and verify that the value of that part is what it should be. But I am not sure if that is worth doing.
Maybe we could figure out a way to validate the values passed to `-s scheme=...`, and fail immediately if the scheme cannot be safely set with `curl_url_set()` instead of checking at runtime.

---
~~MEMO: once, the PR that changes tests.json's format is merged, add a test that verifies that `trurl -s host=hi` exits non-zero, because even before I added the last commit, the test suit didn't detect it was not working correctly.~~
