### PR TITLE
no printing trimmed querys in json output

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -1524,17 +1524,68 @@
                     "port": "443",
                     "path": "/",
                     "query": "",
+                    "params": []
+                }
+            ],
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--json",
+                "--trim",
+                "query=f*",
+                "localhost?foo&bar=ar"
+            ]
+        },
+        "expected": {
+            "stdout": [
+                {
+                    "url": "http://localhost/?bar=ar",
+                    "scheme": "http",
+                    "host": "localhost",
+                    "port": "80",
+                    "path": "/",
+                    "query": "bar=ar",
                     "params": [
                         {
-                            "key": "",
-                            "value": ""
+                            "key": "bar",
+                            "value": "ar"
+                        }
+                    ]
+                }
+            ],
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "https://example.com?search=hello&utm_source=tracker&utm_block&testing",
+                "--trim",
+                "query=utm_*",
+                "--json"
+            ]
+        },
+        "expected": {
+            "stdout": [
+                {
+                    "url": "https://example.com/?search=hello&testing",
+                    "scheme": "https",
+                    "host": "example.com",
+                    "port": "443",
+                    "path": "/",
+                    "query": "search=hello&testing",
+                    "params": [
+                        {
+                            "key": "search",
+                            "value": "hello"
                         },
                         {
-                            "key": "",
-                            "value": ""
-                        },
-                        {
-                            "key": "",
+                            "key": "testing",
                             "value": ""
                         }
                     ]
@@ -1544,4 +1595,5 @@
             "stderr": ""
         }
     }
-]
+
+            ]

--- a/trurl.c
+++ b/trurl.c
@@ -689,14 +689,20 @@ static void json(struct option *o, CURLU *uh)
       curl_free(nurl);
     }
   }
+  first = true;
   if(nqpairs) {
     int i;
     fputs(",\n    \"params\": [\n", stdout);
     for(i = 0 ; i < nqpairs; i++) {
       const char *sep = strchr(qpairsdec[i], '=');
       const char *value = sep ? sep + 1 : "";
-      if(i)
+
+      /* don't print out empty/trimmed values */
+      if(!qpairsdec[i][0])
+          continue;
+      if(!first)
         fputs(",\n", stdout);
+      first = false;
       fputs("      {\n        \"key\": ", stdout);
       jsonString(stdout, qpairsdec[i],
                  sep ? (size_t)(sep - qpairsdec[i]) : strlen(qpairsdec[i]),


### PR DESCRIPTION
previously if you trimmed a query and requested a json output trurl would print a set of empty key/value pairs