### PR TITLE
trurl: fix query splitting

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -1486,5 +1486,55 @@
             "returncode": 7,
             "stderr": "trurl error: not enough input for a URL\ntrurl error: Try trurl -h for help\n"
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-g",
+                "{query:}",
+                "http://localhost/?=bar"
+            ]
+        },
+        "expected": {
+            "stdout": "bar\n",
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--json",
+                "https://curl.se/?&&&"
+            ]
+        },
+        "expected": {
+            "stdout": [
+                {
+                    "url": "https://curl.se/",
+                    "scheme": "https",
+                    "host": "curl.se",
+                    "port": "443",
+                    "path": "/",
+                    "query": "",
+                    "params": [
+                        {
+                            "key": "",
+                            "value": ""
+                        },
+                        {
+                            "key": "",
+                            "value": ""
+                        },
+                        {
+                            "key": "",
+                            "value": ""
+                        }
+                    ]
+                }
+            ],
+            "returncode": 0,
+            "stderr": ""
+        }
     }
 ]


### PR DESCRIPTION
`curl_easy_unescape(NULL, str, ilen, &olen)` interprets 0 ilen as equivalent to `strlen(str)`. The code was not taking this into account, and was expecting the function to return "" in that case which was causing various bugs.
I replaced calls to `curl_easy_unescape()` with calls to a new `strurldecode()` wrapper function that calls `curl_easy_unescape()` with "" instead of str if ilen is 0 to work around the implicit `strlen()` behaviour.

`jsonString()` had the same problem. To fix this issue, I removed its implicit `strlen()` behaviour, and just called `strlen()` where necessary.

I also added some tests.

---

Output of `./trurl -g '{query:}' 'localhost?=bar'` before this patch:
```
bar=bar
```
Output of `./trurl -g '{query:}' 'localhost?=bar&&foo=baz&bar'` before this patch:
```
bar&&foo=baz&bar=bar
```

Output of `./trurl --json 'localhost?foo=bar&&baz=2&&&'` before this patch:
```json
[
  {
    "url": "http://localhost/?foo=bar&baz=2",
    "scheme": "http",
    "host": "localhost",
    "port": "80",
    "path": "/",
    "query": "foo=bar&baz=2",
    "params": [
      {
        "key": "foo",
        "value": "bar"
      },
      {
        "key": "&baz",
        "value": "2&&&"
      },
      {
        "key": "baz",
        "value": "2"
      },
      {
        "key": "&&",
        "value": ""
      },
      {
        "key": "&",
        "value": ""
      }
    ]
  }
]
```

---

I also noticed that trurl currently removes empty query entries, but only if they don't have =.
```
$ ./trurl 'localhost?foo&&&bar&&=&&&#x'
http://localhost/?foo&bar&=#x
```

I am not sure that this is intended, but it happens because there is currently no way to distinguish a empty entry without equal and a trimmed entry.

Also note that one of my tests (the one that uses `&&` in the query of the URL) is probably incompatible with #169 because of this.
