### PR TITLE
--help exits with 0

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -176,7 +176,7 @@ static void help(void)
     fprintf(stderr, "%s%s", i?", ":"", variables[i].name);
   }
   fprintf(stderr, "\n");
-  exit(1);
+  exit(0);
 }
 
 static void show_version(void)


### PR DESCRIPTION
trurl was exiting with 1 when running `--help`, this doesn't seem common for most programs so this PR has it return 0. 