### PR TITLE
Makefile: make test-memory depend on $TARGET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ clean:
 test: $(TARGET)
 	@$(PYTHON3) test.py
 
-test-memory:
+.PHONY: test-memory
+test-memory: $(TARGET)
 	@$(PYTHON3) test.py --with-valgrind
 
 .PHONY: checksrc


### PR DESCRIPTION
Since we need an actual compiled trurl to run the valgrind tests, make test-memory depend on $(TARGET).

This also adds a .PHONY to test-memory, since test, checksrc, clean and install all have those.