### PR TITLE
trurl: fix URL handle leak for invalid URLs

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -1716,5 +1716,19 @@
             "returncode": 11,
             "stderr": "trurl error: duplicate --iterate and --set for component host\ntrurl error: Try trurl -h for help\n"
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "emanuele6://curl.se/trurl",
+                "",
+                "https://example.org"
+            ]
+        },
+        "expected": {
+            "stdout": "emanuele6://curl.se/trurl\nhttps://example.org/\n",
+            "returncode": 0,
+            "stderr": "trurl note: No host part in the URL []\n"
+        }
     }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -972,6 +972,7 @@ static void singleurl(struct option *o,
     if(url) {
       CURLUcode rc = urlfromstring(o, uh, url);
       if(rc) {
+        curl_free(uh);
         VERIFY(o, ERROR_BADURL, "%s [%s]", curl_url_strerror(rc), url);
         return;
       }


### PR DESCRIPTION
Before this patch, when trurl encountered a invalid URL, it skipped it without freeing the URL handle.
This was not discovered earlier because all the tests with invalid URLs were using `--verify` so trurl aborted immediately when encountering invalid URLs, and valgrind couldn't detect the memory leak.