### PR TITLE
--redirect: don't silently ignore failed redirections.

### DIFF
--- a/test.py
+++ b/test.py
@@ -26,6 +26,17 @@ class CommandOutput:
     stderr: str
 
 
+def testComponent(value, exp):
+    if isinstance(exp, bool):
+        result = value == 0 or value not in ("", [])
+        if exp:
+            return result
+        else:
+            return not result
+
+    return value == exp
+
+
 class TestCase:
     def __init__(self, testIndex, baseCmd, **testCase):
         self.testIndex = testIndex
@@ -52,14 +63,14 @@ class TestCase:
             encoding="utf-8"
         )
 
-        if type(self.expected["stdout"]) == str:
-            stdout = output.stdout
-        else:
+        if isinstance(self.expected["stdout"], list):
             # if we dont expect string, parse to json
             try:
                 stdout = json.loads(output.stdout)
             except json.decoder.JSONDecodeError:
                 stdout = None
+        else:
+            stdout = output.stdout
 
         # assume stderr is always going to be string
         stderr = output.stderr
@@ -69,13 +80,9 @@ class TestCase:
 
     def test(self):
         # return true only if stdout, stderr and errorcode is equal to the ones found in testfile
-
-        tests = []
-        for item in self.expected:
-            passed = self.expected[item] == asdict(self.commandOutput)[item]
-            tests.append(passed)
-
-        self.testPassed = all(tests)
+        self.testPassed = all(
+            testComponent(asdict(self.commandOutput)[k], exp)
+            for k, exp in self.expected.items())
         return self.testPassed
 
     def printVerbose(self):
@@ -83,17 +90,20 @@ class TestCase:
         self.printConcise()
         print(NOCOLOR, end="")
 
-        for item in self.expected:
-            itemFail = self.expected[item] != asdict(self.commandOutput)[item]\
-                    and self.commandOutput.returncode == 1
+        for component, exp in self.expected.items():
+            value = asdict(self.commandOutput)[component]
+            itemFail = self.commandOutput.returncode == 1 and \
+                not testComponent(value, exp)
 
-            print(f"--- {item} --- ")
+            print(f"--- {component} --- ")
             print("expected:")
-            print(f"{self.expected[item]!r}")
+            print("nothing" if exp is False else
+                  "something" if exp is True else
+                  f"{exp!r}")
             print("got:")
             if itemFail:
                 print(RED, end="")
-            print(f"{asdict(self.commandOutput)[item]!r}")
+            print(f"{value!r}")
             if itemFail:
                 print(NOCOLOR, end="")
 

--- a/tests.json
+++ b/tests.json
@@ -1761,5 +1761,35 @@
             "returncode": 0,
             "stderr": "trurl note: Bad scheme [foo]\ntrurl note: Bad scheme [hi]\ntrurl note: Bad scheme [hey]\n"
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--accept-space",
+                "--redirect",
+                "https://example.org/a b",
+                "https://curl.se"
+            ]
+        },
+        "expected": {
+            "stdout": "https://example.org/a%20b\n",
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--verify",
+                "--redirect",
+                "https://example.org/a b",
+                "https://curl.se"
+            ]
+        },
+        "expected": {
+            "stdout": "",
+            "returncode": 9,
+            "stderr": true
+        }
     }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -976,7 +976,7 @@ static void singleurl(struct option *o,
     if(url) {
       CURLUcode rc = seturl(o, uh, url);
       if(rc) {
-        curl_free(uh);
+        curl_url_cleanup(uh);
         VERIFY(o, ERROR_BADURL, "%s [%s]", curl_url_strerror(rc), url);
         return;
       }


### PR DESCRIPTION
If a redirection fails, report the failure to stderr, and go to the next URL, or abort if running with --verify. Instead of silently ignoring the failure and carrying on.

This patch also renames urlfromstring() to seturl(), and implements --redirect with it so that curl_url_set() is called with the same flags used to parse base URLs.

Which means the following command will now work:

  $ trurl --accept-space --redirect 'x://foo/a b' curl.se
  x://foo/a%20b