### PR TITLE
Remove set url

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -311,6 +311,8 @@ static void setadd(struct option *o,
 {
   struct curl_slist *n;
   n = curl_slist_append(o->set_list, set);
+  if(!strncmp("url=", set, 4))
+      errorf(ERROR_SET, "--set does not support url, use --redirect instead");
   if(n)
     o->set_list = n;
 }

--- a/trurl.c
+++ b/trurl.c
@@ -312,7 +312,7 @@ static void setadd(struct option *o,
   struct curl_slist *n;
   n = curl_slist_append(o->set_list, set);
   if(!strncmp("url=", set, 4))
-      errorf(ERROR_SET, "--set does not support url, use --redirect instead");
+    errorf(ERROR_SET, "--set does not support url, use --redirect instead");
   if(n)
     o->set_list = n;
 }

--- a/trurl.c
+++ b/trurl.c
@@ -310,9 +310,9 @@ static void setadd(struct option *o,
                    const char *set) /* [component]=[data] */
 {
   struct curl_slist *n;
-  n = curl_slist_append(o->set_list, set);
   if(!strncmp("url", set, 3))
     errorf(ERROR_SET, "--set does not support url, use --redirect instead");
+  n = curl_slist_append(o->set_list, set);
   if(n)
     o->set_list = n;
 }
@@ -321,9 +321,9 @@ static void iteradd(struct option *o,
                     const char *iter) /* [component]=[data] */
 {
   struct curl_slist *n;
-  n = curl_slist_append(o->iter_list, iter);
   if(!strncmp("url", iter, 3))
-    errorf(ERROR_SET, "--iterate does not support url");
+    errorf(ERROR_ITER, "--iterate does not support url");
+  n = curl_slist_append(o->iter_list, iter);
   if(n)
     o->iter_list = n;
 }

--- a/trurl.c
+++ b/trurl.c
@@ -311,7 +311,7 @@ static void setadd(struct option *o,
 {
   struct curl_slist *n;
   n = curl_slist_append(o->set_list, set);
-  if(!strncmp("url=", set, 4))
+  if(!strncmp("url", set, 3))
     errorf(ERROR_SET, "--set does not support url, use --redirect instead");
   if(n)
     o->set_list = n;
@@ -322,6 +322,8 @@ static void iteradd(struct option *o,
 {
   struct curl_slist *n;
   n = curl_slist_append(o->iter_list, iter);
+  if(!strncmp("url", iter, 3))
+    errorf(ERROR_SET, "--iterate does not support url");
   if(n)
     o->iter_list = n;
 }


### PR DESCRIPTION
As @emanuele6 mentioned in #201 using url with --set should be removed. This PR has trurl report an error and provides the following message: `--set does not support url, use --redirect instead`