### PR TITLE
trurl: restructure JSON, add --default-port, --keep-port, --punycode

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -1804,5 +1804,19 @@
             "returncode": 0,
             "stderr": "trurl note: Bad scheme [foo]\ntrurl note: Bad scheme [hi]\ntrurl note: Bad scheme [hey]\n"
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-f",
+                "/dev/null",
+                "--json"
+            ]
+        },
+        "expected": {
+            "stdout": "[]\n",
+            "returncode": 0,
+            "stderr": ""
+        }
     }
 ]

--- a/tests.json
+++ b/tests.json
@@ -305,6 +305,7 @@
     {
         "input": {
             "arguments": [
+                "--default-port",
                 "--url",
                 "https://curl.se/we/are.html",
                 "--get",
@@ -490,7 +491,7 @@
                 "--url",
                 "https://curl.se/we/are.html",
                 "-g",
-                "{port}"
+                "{default:port}"
             ]
         },
         "expected": {
@@ -1254,17 +1255,17 @@
     {
         "input": {
             "arguments": [
-                "localhost",
+                "hello@localhost",
                 "--iterate",
                 "host=one two",
                 "-g",
-                "{host} {port}"
+                "{host} {user}"
             ]
         },
         "expected": {
             "stderr": "",
             "returncode": 0,
-            "stdout": "one 80\ntwo 80\n"
+            "stdout": "one hello\ntwo hello\n"
         }
     },
     {
@@ -1280,12 +1281,12 @@
             "stdout": [
                 {
                     "url": "https://example.com/?utm=tra%20cker&address%20=home&here=now&thisthen",
-                    "scheme": "https",
-                    "host": "example.com",
-                    "port": "443",
-                    "raw_port": "",
-                    "path": "/",
-                    "query": "utm=tra cker&address =home&here=now&thisthen",
+                    "parts": {
+                        "scheme": "https",
+                        "host": "example.com",
+                        "path": "/",
+                        "query": "utm=tra%20cker&address%20=home&here=now&thisthen"
+                    },
                     "params": [
                         {
                             "key": "utm",
@@ -1321,15 +1322,16 @@
             "stdout": [
                 {
                     "url": "ftp://smith:secret@example.com:33/path?search=me#where",
-                    "scheme": "ftp",
-                    "host": "example.com",
-                    "port": "33",
-                    "raw_port": "33",
-                    "path": "/path",
-                    "user": "smith",
-                    "password": "secret",
-                    "query": "search=me",
-                    "fragment": "where",
+                    "parts": {
+                        "scheme": "ftp",
+                        "user": "smith",
+                        "password": "secret",
+                        "host": "example.com",
+                        "port": "33",
+                        "path": "/path",
+                        "query": "search=me",
+                        "fragment": "where"
+                    },
                     "params": [
                         {
                             "key": "search",
@@ -1353,11 +1355,11 @@
             "stdout": [
                 {
                     "url": "http://example.com/",
-                    "scheme": "http",
-                    "host": "example.com",
-                    "port": "80",
-                    "raw_port": "",
-                    "path": "/"
+                    "parts": {
+                        "scheme": "http",
+                        "host": "example.com",
+                        "path": "/"
+                    }
                 }
             ]
         }
@@ -1376,19 +1378,19 @@
             "stdout": [
                 {
                     "url": "http://example.com/",
-                    "scheme": "http",
-                    "host": "example.com",
-                    "port": "80",
-                    "raw_port": "",
-                    "path": "/"
+                    "parts": {
+                        "scheme": "http",
+                        "host": "example.com",
+                        "path": "/"
+                    }
                 },
                 {
                     "url": "http://other.com/",
-                    "scheme": "http",
-                    "host": "other.com",
-                    "port": "80",
-                    "raw_port": "",
-                    "path": "/"
+                    "parts": {
+                        "scheme": "http",
+                        "host": "other.com",
+                        "path": "/"
+                    }
                 }
             ]
         }
@@ -1408,19 +1410,19 @@
             "stdout": [
                 {
                     "url": "http://one/",
-                    "scheme": "http",
-                    "host": "one",
-                    "port": "80",
-                    "raw_port": "",
-                    "path": "/"
+                    "parts": {
+                        "scheme": "http",
+                        "host": "one",
+                        "path": "/"
+                    }
                 },
                 {
                     "url": "http://two/",
-                    "scheme": "http",
-                    "host": "two",
-                    "port": "80",
-                    "raw_port": "",
-                    "path": "/"
+                    "parts": {
+                        "scheme": "http",
+                        "host": "two",
+                        "path": "/"
+                    }
                 }
             ]
         }
@@ -1439,10 +1441,11 @@
             "stdout": [
                 {
                     "url": "irc://curl.se/",
-                    "scheme": "irc",
-                    "host": "curl.se",
-                    "raw_port": "",
-                    "path": "/"
+                    "parts": {
+                        "scheme": "irc",
+                        "host": "curl.se",
+                        "path": "/"
+                    }
                 }
             ],
             "returncode": 0,
@@ -1477,11 +1480,11 @@
             "stdout": [
                 {
                     "url": "ftp://example.org/",
-                    "scheme": "ftp",
-                    "host": "example.org",
-                    "port": "21",
-                    "raw_port": "",
-                    "path": "/"
+                    "parts": {
+                        "scheme": "ftp",
+                        "host": "example.org",
+                        "path": "/"
+                    }
                 }
             ],
             "returncode": 9,
@@ -1526,12 +1529,12 @@
             "stdout": [
                 {
                     "url": "https://curl.se/",
-                    "scheme": "https",
-                    "host": "curl.se",
-                    "port": "443",
-                    "raw_port": "",
-                    "path": "/",
-                    "query": "",
+                    "parts": {
+                        "scheme": "https",
+                        "host": "curl.se",
+                        "path": "/",
+                        "query": ""
+                    },
                     "params": []
                 }
             ],
@@ -1552,12 +1555,12 @@
             "stdout": [
                 {
                     "url": "http://localhost/?bar=ar",
-                    "scheme": "http",
-                    "host": "localhost",
-                    "port": "80",
-                    "raw_port": "",
-                    "path": "/",
-                    "query": "bar=ar",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "localhost",
+                        "path": "/",
+                        "query": "bar=ar"
+                    },
                     "params": [
                         {
                             "key": "bar",
@@ -1583,12 +1586,12 @@
             "stdout": [
                 {
                     "url": "https://example.com/?search=hello&testing",
-                    "scheme": "https",
-                    "host": "example.com",
-                    "port": "443",
-                    "raw_port": "",
-                    "path": "/",
-                    "query": "search=hello&testing",
+                    "parts": {
+                        "scheme": "https",
+                        "host": "example.com",
+                        "path": "/",
+                        "query": "search=hello&testing"
+                    },
                     "params": [
                         {
                             "key": "search",
@@ -1610,7 +1613,7 @@
             "arguments": [
                 "https://räksmörgås.se",
                 "-g",
-                "{puny:url}"
+                "{default:puny:url}"
             ]
         },
         "required": ["punycode"],
@@ -1618,6 +1621,21 @@
             "stderr": "",
             "returncode": 0,
             "stdout": "https://xn--rksmrgs-5wao1o.se:443/\n"
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "https://räksmörgås.se",
+                "-g",
+                "{puny:url}"
+            ]
+        },
+        "required": ["punycode"],
+        "expected": {
+            "stderr": "",
+            "returncode": 0,
+            "stdout": "https://xn--rksmrgs-5wao1o.se/\n"
         }
     },
     {
@@ -1647,17 +1665,18 @@
             "stdout": [
                 {
                     "url": "imaps://user:pasword;crazy@[ff00::1234%25hello]:1234/path?a=b&c=d#fragment",
-                    "scheme": "imaps",
-                    "user": "user",
-                    "password": "pasword",
-                    "options": "crazy",
-                    "host": "[ff00::1234]",
-                    "port": "1234",
-                    "raw_port": "1234",
-                    "path": "/path",
-                    "query": "a=b&c=d",
-                    "fragment": "fragment",
-                    "zoneid": "hello",
+                    "parts": {
+                        "scheme": "imaps",
+                        "user": "user",
+                        "password": "pasword",
+                        "options": "crazy",
+                        "host": "[ff00::1234]",
+                        "port": "1234",
+                        "path": "/path",
+                        "query": "a=b&c=d",
+                        "fragment": "fragment",
+                        "zoneid": "hello"
+                    },
                     "params": [
                         {
                             "key": "a",
@@ -1677,12 +1696,12 @@
             "arguments": [
                 "http://example.com/",
                 "--get",
-                "port: {port}, raw port: {raw:port}"
+                "port: {port}, default:port: {default:port}"
             ]
         },
         "expected": {
             "returncode": 0,
-            "stdout": "port: 80, raw port: \n"
+            "stdout": "port: , default:port: 80\n"
         }
     },
     {
@@ -1690,12 +1709,12 @@
             "arguments": [
                 "http://example.com:8080/",
                 "--get",
-                "port: {port}, raw port: {raw:port}"
+                "port: {port}, default:port: {default:port}"
             ]
         },
         "expected": {
             "returncode": 0,
-            "stdout": "port: 8080, raw port: 8080\n"
+            "stdout": "port: 8080, default:port: 8080\n"
         }
     },
     {
@@ -1784,36 +1803,6 @@
             "stdout": "https://example.org/\ngit://curl.se/\n",
             "returncode": 0,
             "stderr": "trurl note: Bad scheme [foo]\ntrurl note: Bad scheme [hi]\ntrurl note: Bad scheme [hey]\n"
-        }
-    },
-    {
-        "input": {
-            "arguments": [
-                "--accept-space",
-                "--redirect",
-                "https://example.org/a b",
-                "https://curl.se"
-            ]
-        },
-        "expected": {
-            "stdout": "https://example.org/a%20b\n",
-            "returncode": 0,
-            "stderr": ""
-        }
-    },
-    {
-        "input": {
-            "arguments": [
-                "--verify",
-                "--redirect",
-                "https://example.org/a b",
-                "https://curl.se"
-            ]
-        },
-        "expected": {
-            "stdout": "",
-            "returncode": 9,
-            "stderr": true
         }
     }
 ]

--- a/tests.json
+++ b/tests.json
@@ -1818,5 +1818,21 @@
             "returncode": 0,
             "stderr": ""
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--accept-space",
+                "-s",
+                "query:=x=10&x=2 3",
+                "localhost"
+            ]
+        },
+        "required": ["white-space"],
+        "expected": {
+            "stdout": "http://localhost/?x=10&x=2+3\n",
+            "returncode": 0,
+            "stderr": ""
+        }
     }
 ]

--- a/trurl.1
+++ b/trurl.1
@@ -50,6 +50,16 @@ encode such occurrences accordingly.
 
 According to RFC 3986, a space cannot legally be part of a URL. This option
 provides a best-effort to convert the provided string into a valid URL.
+.IP "--default-port"
+When set, trurl will use the scheme's default port number for URLs with a known
+scheme, and without an explicit port number.
+
+Note that trurl only knows default port numbers for URL schemes that are
+supported by libcurl.
+
+Since, by default, trurl removes default port numbers from URLs with a known
+scheme, this option is pretty much ignored unless one of \fI--get\fP,
+\fI--json\fP, and \fI--keep-port\fP is not also specified.
 .IP "-f, --url-file [file name]"
 Read URLs to work on from the given file. Use the file name "-" (a single
 minus) to tell trurl to read the URLs from stdin.
@@ -71,8 +81,26 @@ command line.
 The following component names are available (case sensitive): url, scheme,
 user, password, options, host, port, path, query, fragment and zoneid.
 
+\fB{component}\fP will expand to nothing if the given component does
+not have a value.
+
 Components are shown URL decoded by default. If you instead write the
 component prefixed with a colon like "{:path}", it gets output URL encoded.
+
+You may also prefix components with \fBdefault:\fP and/or \fBpuny:\fP,
+in any order.
+
+If \fBdefault:\fP is specified, like "{default:url}" or
+"{default:port}", and the port is not explicitly specified in the URL,
+the scheme's default port will be output if it is known.
+
+If \fBpuny:\fP is specified, like "{puny:url}" or "{puny:host}", the
+"punycoded" version of the host name will be used in the ouptut.
+
+If \fI--default-port\fP is specified, all formats are expanded as if
+they used \fIdefault:\fP; and if \fI--punycode\fP is used, all formats
+are expanded as if they used \fIpuny:\fP. Also note that "{url}" is
+affected by the \fI--keep-port\fP option.
 
 Hosts provided as IPv6 numerical addresses will be provided within square
 brackets. Like "[fe80::20c:29ff:fe9c:409b]".
@@ -89,16 +117,6 @@ output.
 You can access specific keys in the query string and out all values using the
 format \fB{query-all:key}\fP. This looks for 'key' case sensitively and will
 output all values for that key space-separated.
-
-You can access the url and host components in their "punycoded" version, which
-is how International Domain Names are converted into plain ASCII, by using the
-form \fB{puny:url}\fP and \fB{puny:host}\fP. If the host name is not using
-IDN, this option provides the regular ASCII name.
-
-You can determine if a port is explicitly defined in a URL by using the "raw"
-keyword in your format string, which would look like \fB{raw:port}\fP. If the
-port is explicitly defined trurl will return the port number, if it is not
-explicitly defined then trurl will return an empty string.
 
 The "format" string supports the following backslash sequences:
 
@@ -124,11 +142,19 @@ but only one \fI--iterate\fP option per component. The listed items to iterate
 over should be separated by single spaces.
 .IP "--json"
 Outputs all set components of the URLs as JSON objects. All components of the
-URL that has data will get populated in the object using their component
-names. See below for details on the format.
+URL that have data will get populated in the parts object using their
+component names. See below for details on the format.
+.IP "--keep-port"
+By default, trurl removes default port numbers from URLs with a known scheme
+even if they are explictly specified in the input URL. This options, makes
+trurl not remove them.
 .IP "--no-guess-scheme"
 Disables libcurl's scheme guessing feature. URLs that do not contain a scheme
 will be treated as invalid URLs.
+.IP "--punycode"
+Uses the "punycoded" version of the host name, which is how International Domain
+Names are converted into plain ASCII. If the host name is not using IDN, the
+regular ASCII name is used.
 .IP "--query-separator [what]"
 Specify the single letter used for separating query pairs. The default is "&"
 but at least in the past sometimes semicolons ";" or even colons ":" have been
@@ -185,38 +211,51 @@ each URL.
 Each URL JSON object contains a number of properties, a series of key/value
 pairs. The exact set depends on the given URL.
 .IP "url"
-This key exists in every object. It is the complete URL, in a URL encoded
-format.
-.IP "scheme"
+This key exists in every object. It is the complete URL. Affected by
+\fI--default-port\fP, \fI--keep-port\fP, and \fI--punycode\fP.
+.IP "parts"
+This key exists in every object, and contains an object with a key for
+each of the settable URL components. If a component is missing, it means
+it is not present in the URL.
+.RS
+.TP
+.B "scheme"
 The URL scheme.
-.IP "user"
+.TP
+.B "user"
 The URL decoded user name.
-.IP "password"
+.TP
+.B "password"
 The URL decoded password.
-.IP "options"
+.TP
+.B "options"
 The URL decoded options. Note that only a few URL schemes support the
 "options" component.
-.IP "host"
+.TP
+.B "host"
 The URL decoded and normalized host name. It might be a UTF-8 name if an IDN
-name was used. It can also be a normalized IPv4 or IPv6 address. An IPv6
-address always starts with a bracket (\fB[\fP) - and no other host names can
-contain such a symbol.
-.IP "port"
-The provided port number. If the port number was not provided in the URL, but
-the scheme is a known one, the default port for that scheme will be provided
-here.
-.IP "raw_port"
-The port number exactly as provided in the URL. This will be a zero length
-string if there was no explicit port number provided.
-.IP "path"
+name was used. It can also be a normalized IPv4 or IPv6 address. An IPv6 address
+always starts with a bracket (\fB[\fP) - and no other host names can contain
+such a symbol.
+.TP
+.B "port"
+The provided port number as a string. If the port number was not provided in the
+URL, but the scheme is a known one, and \fI--default-port\fP is in use, the
+default port for that scheme will be provided here.
+.TP
+.B "path"
 The URL decoded path. Including the leading slash.
-.IP "query"
+.TP
+.B "query"
 The URL decoded full query, excluding the question mark separator.
-.IP "fragment"
+.TP
+.B "fragment"
 The URL decoded fragment, excluding the pound sign separator.
-.IP "zoneid"
+.TP
+.B "zoneid"
 The zone id, which can only be present in an IPv6 address. When this key is
 present, then \fBhost\fP is an IPv6 numerical address.
+.RE
 .IP "params"
 This key contains an array of query key/value objects. Each such pair is
 listed with "key" and "value" and their respective contents in the output.
@@ -225,7 +264,9 @@ The key/values are extracted from the query where they are separated by
 ampersands (\fB&\fP) - or the user sets with \fB--query-separator\fP.
 
 The query pairs are listed in the order of appearance in a left-to-right
-order, but can be made alpha-sorted with \fB--sort-query\fP
+order, but can be made alpha-sorted with \fB--sort-query\fP.
+
+It is only present if the URL has a query.
 .SH EXAMPLES
 .IP "Replace the host name of a URL"
 .nf
@@ -244,7 +285,6 @@ https://curl.se/we/here.html
 .fi
 .IP "Change port number"
 This also shows how trurl will remove dot-dot sequences
-
 .nf
 $ trurl --url https://curl.se/we/../are.html --set port=8080
 https://curl.se:8080/are.html
@@ -257,9 +297,8 @@ $ trurl --url https://curl.se/we/are.html --get '{path}'
 .IP "Extract the port from a URL"
 This gets the default port based on the scheme if the port is not set in the
 URL.
-
 .nf
-$ trurl --url https://curl.se/we/are.html --get '{port}'
+$ trurl --url https://curl.se/we/are.html --get '{default:port}'
 443
 .fi
 .IP "Append a path segment to a URL"
@@ -283,13 +322,13 @@ $ trurl "https://fake.host/search?q=answers&user=me#frag" --json
 [
   {
     "url": "https://fake.host/search?q=answers&user=me#frag",
-    "scheme": "https",
-    "host": "fake.host",
-    "port": "443",
-    "raw_port": "",
-    "path": "/search",
-    "query": "q=answers&user=me",
-    "fragment": "frag",
+    "parts": [
+        "scheme": "https",
+        "host": "fake.host",
+        "path": "/search",
+        "query": "q=answers&user=me"
+        "fragment": "frag",
+    ],
     "params": [
       {
         "key": "q",
@@ -337,3 +376,6 @@ sftp://curl.se/path/index.html
 .fi
 .SH WWW
 https://curl.se/trurl
+.SH "SEE ALSO"
+.BR curl_url_set (3)
+.BR curl_url_get (3)

--- a/trurl.c
+++ b/trurl.c
@@ -1199,12 +1199,12 @@ static void singleurl(struct option *o,
         else {
           char *nurl = NULL;
           rc = curl_url_get(uh, CURLUPART_URL, &nurl, 0);
-          if(rc || strcmp(ourl, nurl)) {
+          if(!rc)
+            curl_free(nurl);
+          else {
             VERIFY(o, ERROR_BADURL, "url became invalid");
             url_is_invalid = true;
           }
-          if(!rc)
-            curl_free(nurl);
         }
         curl_free(ourl);
       }

--- a/trurl.c
+++ b/trurl.c
@@ -351,8 +351,6 @@ static void setadd(struct option *o,
                    const char *set) /* [component]=[data] */
 {
   struct curl_slist *n;
-  if(!strncmp("url", set, 3))
-    errorf(ERROR_SET, "--set does not support url, use --redirect instead");
   n = curl_slist_append(o->set_list, set);
   if(n)
     o->set_list = n;
@@ -362,8 +360,6 @@ static void iteradd(struct option *o,
                     const char *iter) /* [component]=[data] */
 {
   struct curl_slist *n;
-  if(!strncmp("url", iter, 3))
-    errorf(ERROR_ITER, "--iterate does not support url");
   n = curl_slist_append(o->iter_list, iter);
   if(n)
     o->iter_list = n;

--- a/trurl.c
+++ b/trurl.c
@@ -150,13 +150,14 @@ static void errorf(int exit_code, char *fmt, ...)
 
 #define VERIFY(op, exit_code, ...) \
   do { \
-    if(op->verify) { \
+    if(!op->verify) \
+      warnf(__VA_ARGS__); \
+    else { \
       /* make sure to terminate the JSON array */ \
       if(op->jsonout) \
         printf("%s]\n", op->urls ? "\n" : ""); \
       errorf(exit_code, __VA_ARGS__); \
-    } else \
-      warnf(__VA_ARGS__); \
+    } \
   } while(0)
 
 static void help(void)

--- a/trurl.c
+++ b/trurl.c
@@ -153,7 +153,7 @@ static void errorf(int exit_code, char *fmt, ...)
     if(op->verify) { \
       /* make sure to terminate the JSON array */ \
       if(op->jsonout) \
-        fputs("\n]\n", stdout); \
+        printf("%s]\n", op->urls ? "\n" : ""); \
       errorf(exit_code, __VA_ARGS__); \
     } else \
       warnf(__VA_ARGS__); \
@@ -798,7 +798,7 @@ static void json(struct option *o, CURLU *uh)
     VERIFY(o, ERROR_BADURL, "invalid url [%s]", curl_url_strerror(rc));
     return;
   }
-  printf("%s  {\n    \"url\": ", o->urls ? ",\n" : "");
+  printf("%s\n  {\n    \"url\": ", o->urls ? "," : "");
   jsonString(stdout, url, strlen(url), false);
   curl_free(url);
   fputs(",\n    \"parts\": {\n", stdout);
@@ -1270,7 +1270,7 @@ int main(int argc, const char **argv)
     o.qsep = "&";
 
   if(o.jsonout)
-    fputs("[\n", stdout);
+    putchar('[');
 
   if(o.url) {
     /* this is a file to read URLs from */
@@ -1346,7 +1346,7 @@ int main(int argc, const char **argv)
     } while(node);
   }
   if(o.jsonout)
-    fputs("\n]\n", stdout);
+    printf("%s]\n", o.urls ? "\n" : "");
   /* we're done with libcurl, so clean it up */
   curl_slist_free_all(o.url_list);
   curl_slist_free_all(o.set_list);


### PR DESCRIPTION
This patch restructures the JSON output with the following format:
```
  {
    "url": // same value as `{url}`
    "parts": {
      ..., // urldecoded URL parts except the URL
    },
    "params": [
       ...
    ],
    // other stuff
  }
```

I decided to remove raw_port for now, since now I think it is less useful than it used to be.

This patch also reworks default output and -g.
`{raw:}` has been removed in favour of `{default:}`.
`{default:}` and `{puny:}` are "get modifiers" like `{:component}`, and may be specified in any order front of a component to modify the curl_url_get() flags used by trurl to get that URL.

`{default:}` makes trurl use CURLU_DEFAULT_PORT, use the libcurl-supported scheme's default port if one is not specified, and `{puny:}` makes trurl use CURLU_PUNYCODE  e.g.

* `{default:port}` will get 80 for `http://example.org/`
* `{puny:host}` will get xn--p-8fa.example.org from `imap://pè.example.org`

`{default:}`, `{puny:}`, and `{:part}` may be specified at the same time in which case multiple additional flags are passed to curl_url_get().

  $ trurl -g '{puny:default:url}' imap://pè.example.org
  imap://xn--p-8fa.example.org:143/

If `--default-port` is used, `{default:}` is implied for every `{}` in the `--get;` and, if `--puny` is implied.

Default output now behaves exactly like  -g '{url}'. (note: previously  -g '{url}'  behaved like the new `{default:url}`, it
       always included, )

This allows more fine tuning of `-g` the output, and default URL output since it was previously not possible to:

* get the URL with explicit default port in the `--json` output
* get the URL without default port in a `--get` format
* get the punycode encoded URL without explicit default port
* get the punycode encoded URL with or without explict port in `--json`

By default, trurl removes redundant explict ports for libcurl-supported schemes, you can use `--keep-port` to inhibit that behaviour.

I fixed a bug that made  -g `{raw:port}`  (or  -g `{port}`) never able to print the default port for libcurl-supported scheme even if the port was explictly specified. (this bug was unique to `{raw:port}`, raw_port in the JSON worked fine.)

I also fixed some inconsistencies in the code, e.g. get() had a output stream variable that was not being propagated to showqkey() that was always outputting to stdout, and failed gets were printing warnings using  printf(stderr, PROGNAME ...)  instead of warnf().

This is only an initial draft, so I have not updated test expectations and the manual yet.

Ref: #201
