### PR TITLE
ci: don't unnecessarily install "packaging" on macOS

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -70,11 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install -r requirements.txt
-
       - name: make
         run: make
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-packaging==23.1


### PR DESCRIPTION
The "packaging" python dependency has been removed with 3129d40