### PR TITLE
format null as \u0000 when calling with --json 

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2042,5 +2042,63 @@
                 }
             ]        
         }
+    },
+    {
+        "input" : {
+            "arguments": [
+                "http://example.com/?q=mr%00sm%00ith",
+                "--json"
+            ]
+        },
+        "expected": {
+            "stderr": "",
+            "returncode": 0,
+            "stdout": [
+                {
+                    "url": "http://example.com/?q=mr%00sm%00ith",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "example.com",
+                        "path": "/",
+                        "query": "q=mr%00sm%00ith"
+                    },
+                    "params": [
+                        {
+                            "key": "q",
+                            "value": "mr\u0000sm\u0000ith"
+                        }
+                    ]
+                }
+            ]        
+        }
+    },
+    {
+        "input" : {
+            "arguments": [
+                "http://example.com/?q=mr%00%00%00smith",
+                "--json"
+            ]
+        },
+        "expected": {
+            "stderr": "",
+            "returncode": 0,
+            "stdout": [
+                {
+                    "url": "http://example.com/?q=mr%00%00%00smith",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "example.com",
+                        "path": "/",
+                        "query": "q=mr%00%00%00smith"
+                    },
+                    "params": [
+                        {
+                            "key": "q",
+                            "value": "mr\u0000\u0000\u0000smith"
+                        }
+                    ]
+                }
+            ]        
+        }
     }
 ]

--- a/tests.json
+++ b/tests.json
@@ -2059,8 +2059,7 @@
                     "parts": {
                         "scheme": "http",
                         "host": "example.com",
-                        "path": "/",
-                        "query": "q=mr%00sm%00ith"
+                        "path": "/"
                     },
                     "params": [
                         {
@@ -2088,8 +2087,7 @@
                     "parts": {
                         "scheme": "http",
                         "host": "example.com",
-                        "path": "/",
-                        "query": "q=mr%00%00%00smith"
+                        "path": "/"
                     },
                     "params": [
                         {

--- a/tests.json
+++ b/tests.json
@@ -2014,5 +2014,33 @@
             "returncode": 0,
             "stderr": ""
         }
+    }, 
+    {
+        "input" : {
+            "arguments": [
+                "http://example.com/?q=mr%00smith",
+                "--json"
+            ]
+        },
+        "expected": {
+            "stderr": "",
+            "returncode": 0,
+            "stdout": [
+                {
+                    "url": "http://example.com/?q=mr%00smith",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "example.com",
+                        "path": "/"
+                    },
+                    "params": [
+                        {
+                            "key": "q",
+                            "value": "mr\u0000smith"
+                        }
+                    ]
+                }
+            ]        
+        }
     }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -902,9 +902,9 @@ struct string *memdupzero(char *source, size_t len)
 {
   struct string *ret = malloc(sizeof(struct string));
   if(!ret)
-      return NULL;
+    return NULL;
   ret->str = malloc(len + 1);
-  if(!ret->str) 
+  if(!ret->str)
     return NULL;
   memcpy(ret->str, source, len);
   ret->str[len] = 0;
@@ -1006,7 +1006,6 @@ static char *addqpair(char *pair, size_t len, bool json)
     free(pdec);
   if(p)
     free(p);
-    
   return ret;
 }
 

--- a/trurl.c
+++ b/trurl.c
@@ -908,8 +908,10 @@ struct string *memdupzero(char *source, size_t len)
   if(!ret)
     return NULL;
   ret->str = malloc(len + 1);
-  if(!ret->str)
+  if(!ret->str) {
+    free(ret);
     return NULL;
+  }
   memcpy(ret->str, source, len);
   ret->str[len] = 0;
   ret->len = len;
@@ -954,6 +956,9 @@ struct string *memdupdec(char *source, size_t len, bool json)
   curl_free(right.str);
   curl_free(left.str);
   struct string *ret = malloc(sizeof(struct string));
+  if(!ret) {
+      return NULL;
+  }
   ret->str = str;
   if(right.str)
     ret->len = right.len;
@@ -996,7 +1001,8 @@ static char *addqpair(char *pair, size_t len, bool json)
   else
     warnf("too many query pairs");
 
-  ret = p->str;
+  if(p)
+    ret = p->str;
   if(pdec)
     free(pdec);
   if(p)

--- a/trurl.c
+++ b/trurl.c
@@ -932,6 +932,7 @@ struct string *memdupdec(char *source, size_t len, bool json)
     /* convert null bytes to periods */
     for(plen = right.len, p = right.str; plen; plen--, p++) {
       if(!*p) {
+        /* Doesn't work for multiple null characters */
         if(json) {
           int p_prev  = (uintptr_t)(p - right.str);
           char *newstr = realloc(right.str, right.len + json_null_len);

--- a/trurl.c
+++ b/trurl.c
@@ -913,6 +913,7 @@ struct string *memdupdec(char *source, size_t len, bool json)
 {
   char *sep = memchr(source, '=', len);
   char *json_null_str = "\\u0000";
+  int json_null_len = strlen(json_null_str);
   struct string left;
   struct string right;
   char *str, *dup;
@@ -929,7 +930,7 @@ struct string *memdupdec(char *source, size_t len, bool json)
     right.str[right.len] = '\0';
     char * tmp_right = NULL;
 
-    if(json) {
+    if(json && (right.len != (int) strlen(right.str))) {
       tmp_right = malloc((right.len + strlen(json_null_str) - 1)*sizeof(char));
       memset(tmp_right, 0, right.len + strlen(json_null_str) - 1);
       if(!tmp_right)
@@ -944,8 +945,8 @@ struct string *memdupdec(char *source, size_t len, bool json)
     for(plen = right.len, p = right.str; plen; plen--, p++) {
       if(!*p) {
         if(json) {
-          memmove(p + strlen(json_null_str), p + 1, plen);
-          memcpy(p, json_null_str, strlen(json_null_str));
+          memmove(p + json_null_len, p + 1, plen);
+          memcpy(p, json_null_str, json_null_len);
         }
         else {
           *p = REPLACE_NULL_BYTE;

--- a/trurl.c
+++ b/trurl.c
@@ -941,6 +941,7 @@ struct string *memdupdec(char *source, size_t len, bool json)
           p = right.str + p_prev;
           memmove(p + json_null_len, p + 1, plen);
           memcpy(p, json_null_str, json_null_len);
+          p += json_null_len - 1;
         }
         else {
           *p = REPLACE_NULL_BYTE;

--- a/trurl.c
+++ b/trurl.c
@@ -844,7 +844,7 @@ static void json(struct option *o, CURLU *uh)
                        qpairsdec[j].len,
                  false);
       fputs(",\n        \"value\": ", stdout);
-      jsonString(stdout, value, qpairsdec[j].len, false);
+      jsonString(stdout, sep?value:"", sep?qpairsdec[j].len:0, false);
       fputs("\n      }", stdout);
     }
     fputs("\n    ]", stdout);
@@ -892,7 +892,9 @@ static void trim(struct option *o)
           free(qpairs[i].str);
           free(qpairsdec[i].str);
           qpairs[i].str = strdup(""); /* marked as deleted */
+          qpairs[i].len = 0;
           qpairsdec[i].str = strdup(""); /* marked as deleted */
+          qpairsdec[i].len = 0;
         }
       }
     }
@@ -942,9 +944,10 @@ struct string *memdupdec(char *source, size_t len, bool json)
   }
 
   str = curl_maprintf("%.*s%s%.*s", left.len, left.str,
-                      sep ? "=":"",
-                      right.len, sep?right.str:"");
-  if(sep && json) {
+                      right.str ? "=":"",
+                      right.len, right.str?right.str:"");
+
+  if(sep && right.str) {
       memcpy(str + left.len + 1, right.str, right.len);
   }
   
@@ -952,7 +955,11 @@ struct string *memdupdec(char *source, size_t len, bool json)
   curl_free(left.str);
   struct string *ret = malloc(sizeof(struct string));
   ret->str = str; 
-  ret->len = left.len + right.len - 1;
+  if(right.str)
+      ret->len = right.len;
+  else {
+      ret->len = left.len;
+  }
   //curl_free(str);
   return ret;
 }

--- a/trurl.c
+++ b/trurl.c
@@ -957,7 +957,7 @@ struct string *memdupdec(char *source, size_t len, bool json)
   curl_free(left.str);
   struct string *ret = malloc(sizeof(struct string));
   if(!ret) {
-      return NULL;
+    return NULL;
   }
   ret->str = str;
   if(right.str)

--- a/trurl.c
+++ b/trurl.c
@@ -929,16 +929,17 @@ struct string *memdupdec(char *source, size_t len, bool json)
   right.len = 0;
 
   left.str = strurldecode(source, sep ? (size_t)(sep - source) : len,
-                      (int*)&left.len);
+                      (int *)&left.len);
   if(sep) {
     char *p;
     int plen;
-    right.str = strurldecode(sep + 1, len - (sep - source) - 1, (int*)&right.len);
+    right.str = strurldecode(sep + 1, len - (sep - source) - 1,
+            (int *)&right.len);
 
     /* convert null bytes to periods */
     for(plen = right.len, p = right.str; plen; plen--, p++) {
       if(!*p && !json) {
-          *p = REPLACE_NULL_BYTE;
+        *p = REPLACE_NULL_BYTE;
       }
      }
   }
@@ -948,19 +949,17 @@ struct string *memdupdec(char *source, size_t len, bool json)
                       right.len, right.str?right.str:"");
 
   if(sep && right.str) {
-      memcpy(str + left.len + 1, right.str, right.len);
+    memcpy(str + left.len + 1, right.str, right.len);
   }
-  
   curl_free(right.str);
   curl_free(left.str);
   struct string *ret = malloc(sizeof(struct string));
-  ret->str = str; 
+  ret->str = str;
   if(right.str)
-      ret->len = right.len;
+    ret->len = right.len;
   else {
-      ret->len = left.len;
+    ret->len = left.len;
   }
-  //curl_free(str);
   return ret;
 }
 

--- a/trurl.c
+++ b/trurl.c
@@ -759,7 +759,7 @@ static void jsonString(FILE *stream, const char *in, size_t len,
   for(; i < (unsigned char *)in_end; i++) {
     switch(*i) {
     case '\\':
-      fputs("\\\\", stream);
+      fputs("\\", stream);
       break;
     case '\"':
       fputs("\\\"", stream);
@@ -913,7 +913,7 @@ static char *memdupzero(char *source, size_t len)
 struct string *memdupdec(char *source, size_t len, bool json)
 {
   char *sep = memchr(source, '=', len);
-  char *json_null_str = "\\u0000";
+  const char *json_null_str = "\\u0000";
   int json_null_len = strlen(json_null_str);
   struct string left;
   struct string right;

--- a/trurl.c
+++ b/trurl.c
@@ -918,7 +918,6 @@ struct string *memdupdec(char *source, size_t len, bool json)
   struct string left;
   struct string right;
   char *str, *dup;
-    
   left.str = NULL;
   right.str = NULL;
 
@@ -934,11 +933,11 @@ struct string *memdupdec(char *source, size_t len, bool json)
     for(plen = right.len, p = right.str; plen; plen--, p++) {
       if(!*p) {
         if(json) {
-          int p_len = (uintptr_t)(p - right.str);
+          int p_prev  = (uintptr_t)(p - right.str);
           char *newstr = realloc(right.str, right.len + json_null_len);
           right.str = newstr;
           right.len += json_null_len;
-          p = right.str + p_len;
+          p = right.str + p_prev;
           memmove(p + json_null_len, p + 1, plen);
           memcpy(p, json_null_str, json_null_len);
         }
@@ -949,17 +948,16 @@ struct string *memdupdec(char *source, size_t len, bool json)
      }
   }
 
-
   str = curl_maprintf("%.*s%s%.*s", left.len, left.str,
                       right.str ? "=":"",
                       right.len, right.str?right.str:"");
   curl_free(right.str);
   curl_free(left.str);
   dup = strdup(str);
-  curl_free(str);
   struct string *ret = malloc(sizeof(struct string));
   ret->str = dup;
   ret->len = strlen(str);
+  curl_free(str);
   return ret;
 }
 
@@ -994,6 +992,10 @@ static char *addqpair(char *pair, size_t len, bool json)
   }
   else
     warnf("too many query pairs");
+
+  if(pdec)
+    free(pdec);
+
   return p;
 }
 

--- a/trurl.c
+++ b/trurl.c
@@ -837,7 +837,8 @@ static void json(struct option *o, CURLU *uh)
       first = false;
       fputs("      {\n        \"key\": ", stdout);
       jsonString(stdout, qpairsdec[j].str,
-                 sep ? (size_t)(sep - qpairsdec[j].str) : strlen(qpairsdec[j].str),
+                 sep ? (size_t)(sep - qpairsdec[j].str) :
+                       strlen(qpairsdec[j].str),
                  false);
       fputs(",\n        \"value\": ", stdout);
       jsonString(stdout, value, strlen(value), false);
@@ -964,7 +965,9 @@ static char *addqpair(char *pair, size_t len)
     pdec = memdupdec(pair, len);
     if(p && pdec) {
       qpairs[nqpairs].str = p;
+      qpairs[nqpairs].len = len;
       qpairsdec[nqpairs].str = pdec;
+      qpairsdec[nqpairs].len = len;
       nqpairs++;
     }
   }
@@ -1007,7 +1010,8 @@ static void qpair2query(CURLU *uh, struct option *o)
   for(i = 0; i<nqpairs; i++) {
     char *oldnq = nq;
     nq = curl_maprintf("%s%s%s", nq?nq:"",
-                       (nq && *nq && *(qpairs[i].str))? o->qsep: "", qpairs[i].str);
+                       (nq && *nq && *(qpairs[i].str))? o->qsep: "",
+                       qpairs[i].str);
     curl_free(oldnq);
   }
   if(nq) {
@@ -1021,16 +1025,19 @@ static void qpair2query(CURLU *uh, struct option *o)
 /* sort case insensitively */
 static int cmpfunc(const void *p1, const void *p2)
 {
-  return strcasecmp(*(const char **)p1,
-                    *(const char **)p2);
+  int len = (((struct string *)p1)->len) < (((struct string *)p2)->len)?
+             (((struct string *)p1)->len):(((struct string *)p2)->len);
+
+  return strncasecmp((((struct string *)p1)->str),
+                    (((struct string *)p2)->str), len);
 }
 
 static void sortquery(struct option *o)
 {
   if(o->sort_query) {
     /* not these two lists may no longer be the same order after the sort */
-    qsort(&qpairs[0], nqpairs, sizeof(char *), cmpfunc);
-    qsort(&qpairsdec[0], nqpairs, sizeof(char *), cmpfunc);
+    qsort(&qpairs[0], nqpairs, sizeof(struct string), cmpfunc);
+    qsort(&qpairsdec[0], nqpairs, sizeof(struct string), cmpfunc);
   }
 }
 

--- a/trurl.c
+++ b/trurl.c
@@ -920,6 +920,8 @@ struct string *memdupdec(char *source, size_t len, bool json)
   char *str, *dup;
   left.str = NULL;
   right.str = NULL;
+  left.len = 0;
+  right.len = 0;
 
   left.str = strurldecode(source, sep ? (size_t)(sep - source) : len,
                       &left.len);
@@ -927,15 +929,15 @@ struct string *memdupdec(char *source, size_t len, bool json)
     char *p;
     int plen;
     right.str = strurldecode(sep + 1, len - (sep - source) - 1, &right.len);
-    right.str[right.len] = '\0';
 
     /* convert null bytes to periods */
     for(plen = right.len, p = right.str; plen; plen--, p++) {
       if(!*p) {
-        /* Doesn't work for multiple null characters */
         if(json) {
           int p_prev  = (uintptr_t)(p - right.str);
           char *newstr = realloc(right.str, right.len + json_null_len);
+          if(!newstr)
+            errorf(ERROR_MEM, "out of memory");
           right.str = newstr;
           right.len += json_null_len;
           p = right.str + p_prev;


### PR DESCRIPTION
- has `--json` encode a null byte as `\u0000` instead of `.` 
- adds `struct string` and makes `qpairs` and `qpairsdec` use this instead of a char*
- fixes #205 