### PR TITLE
Adjust handling CFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET = trurl
 OBJS = trurl.o
 LDLIBS = $$(curl-config --libs)
-CFLAGS = $$(curl-config --cflags) -W -Wall -Wshadow -Werror -pedantic -g
+CFLAGS += $$(curl-config --cflags) -W -Wall -Wshadow -Werror -pedantic -g
 MANUAL = trurl.1
 
 PREFIX ?= /usr/local

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET = trurl
 OBJS = trurl.o
 LDLIBS = $$(curl-config --libs)
-CFLAGS += $$(curl-config --cflags) -W -Wall -Wshadow -Werror -pedantic -g
+CFLAGS += $$(curl-config --cflags) -W -Wall -Wshadow -Werror -pedantic -g -std=gnu99
 MANUAL = trurl.1
 
 PREFIX ?= /usr/local


### PR DESCRIPTION
A couple of changes to allow trurl to be built with legacy toolchains and consistency when packaging.