### PR TITLE
tests: use empty file instead of /dev/null

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -1809,7 +1809,7 @@
         "input": {
             "arguments": [
                 "-f",
-                "/dev/null",
+                "testfiles/test0002.txt",
                 "--json"
             ]
         },


### PR DESCRIPTION
/dev/null won't work in non-cygwin windows builds.

Fixes #213