### PR TITLE
--json/--get: .[].parts and {component} should be urldecoded not encoded; add --urlencode

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -1285,7 +1285,7 @@
                         "scheme": "https",
                         "host": "example.com",
                         "path": "/",
-                        "query": "utm=tra%20cker&address%20=home&here=now&thisthen"
+                        "query": "utm=tra cker&address =home&here=now&thisthen"
                     },
                     "params": [
                         {
@@ -1831,6 +1831,46 @@
         "required": ["white-space"],
         "expected": {
             "stdout": "http://localhost/?x=10&x=2+3\n",
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "path=\\\\",
+                "-g",
+                "{path}\\n{:path}",
+                "localhost"
+            ]
+        },
+        "expected": {
+            "stdout": "/\\\\\n/%5c%5c\n",
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "path=\\\\",
+                "--json",
+                "localhost"
+            ]
+        },
+        "expected": {
+            "stdout": [
+                {
+                    "url": "http://localhost/%5c%5c",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "localhost",
+                        "path": "/\\\\"
+                    }
+                }
+            ],
             "returncode": 0,
             "stderr": ""
         }

--- a/tests.json
+++ b/tests.json
@@ -1874,5 +1874,112 @@
             "returncode": 0,
             "stderr": ""
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "path=\\\\",
+                "-g",
+                "{path}\\n{:path}",
+                "--urlencode",
+                "localhost"
+            ]
+        },
+        "expected": {
+            "stdout": "/%5c%5c\n/%5c%5c\n",
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "path=abc\\\\",
+                "-s",
+                "query:=a&b&a%26b",
+                "--urlencode",
+                "--json",
+                "localhost"
+            ]
+        },
+        "expected": {
+            "stdout": [
+                {
+                    "url": "http://localhost/abc%5c%5c?a&b&a%26b",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "localhost",
+                        "path": "/abc%5c%5c",
+                        "query": "a&b&a%26b"
+                    },
+                    "params": [
+                        {
+                            "key": "a",
+                            "value": ""
+                        },
+                        {
+                            "key": "b",
+                            "value": ""
+                        },
+                        {
+                            "key": "a&b",
+                            "value": ""
+                        }
+                    ]
+                }
+            ],
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "scheme:=http",
+                "-s",
+                "host:=localhost",
+                "-s",
+                "path:=/ABC%5C%5C",
+                "-s",
+                "query:=a&b&a%26b"
+            ]
+        },
+        "expected": {
+            "stdout": "http://localhost/ABC%5c%5c?a&b&a%26b\n",
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-g",
+                "{query:b}\\t{query-all:a}\\n{:query:b}\\t{:query-all:a}",
+                "https://example.org/foo?a=1&b=%23&a=%26#hello"
+            ]
+        },
+        "expected": {
+            "stdout": "#\t1 &\n%23\t1 %26\n",
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--urlencode",
+                "-g",
+                "{query:b}\\t{query-all:a}\\n{:query:b}\\t{:query-all:a}",
+                "https://example.org/foo?a=1&b=%23&a=%26#hello"
+            ]
+        },
+        "expected": {
+            "stdout": "%23\t1 %26\n%23\t1 %26\n",
+            "returncode": 0,
+            "stderr": ""
+        }
     }
 ]

--- a/trurl.1
+++ b/trurl.1
@@ -193,6 +193,9 @@ Providing multiple URLs will make trurl act on all URLs in a serial fashion.
 
 If the URL cannot be parsed for whatever reason, trurl will simply move on to
 the next provided URL - unless \fI--verify\fP is used.
+.IP "--urlencode"
+Outputs URL encoded version of components by default when using \fI--get\fP or
+\fI--json\fP.
 .IP "--trim [component]=[what]"
 Trims data off a component. Currently this can only trim a query component.
 
@@ -216,27 +219,28 @@ This key exists in every object. It is the complete URL. Affected by
 .IP "parts"
 This key exists in every object, and contains an object with a key for
 each of the settable URL components. If a component is missing, it means
-it is not present in the URL.
+it is not present in the URL. The parts are URL decoded unless \fI--urlencode\fP
+is used.
 .RS
 .TP
 .B "scheme"
 The URL scheme.
 .TP
 .B "user"
-The URL decoded user name.
+The user name.
 .TP
 .B "password"
-The URL decoded password.
+The password.
 .TP
 .B "options"
-The URL decoded options. Note that only a few URL schemes support the
-"options" component.
+The options. Note that only a few URL schemes support the "options"
+component.
 .TP
 .B "host"
-The URL decoded and normalized host name. It might be a UTF-8 name if an IDN
-name was used. It can also be a normalized IPv4 or IPv6 address. An IPv6 address
-always starts with a bracket (\fB[\fP) - and no other host names can contain
-such a symbol.
+The and normalized host name. It might be a UTF-8 name if an IDN name was used.
+It can also be a normalized IPv4 or IPv6 address. An IPv6 address always starts
+with a bracket (\fB[\fP) - and no other host names can contain such a symbol. If
+\fI--punycode\fP is used, the punycode version of the host is outputted instead.
 .TP
 .B "port"
 The provided port number as a string. If the port number was not provided in the
@@ -244,13 +248,13 @@ URL, but the scheme is a known one, and \fI--default-port\fP is in use, the
 default port for that scheme will be provided here.
 .TP
 .B "path"
-The URL decoded path. Including the leading slash.
+The path. Including the leading slash.
 .TP
 .B "query"
-The URL decoded full query, excluding the question mark separator.
+The full query, excluding the question mark separator.
 .TP
 .B "fragment"
-The URL decoded fragment, excluding the pound sign separator.
+The fragment, excluding the pound sign separator.
 .TP
 .B "zoneid"
 The zone id, which can only be present in an IPv6 address. When this key is

--- a/trurl.c
+++ b/trurl.c
@@ -77,7 +77,7 @@
 #define REPLACE_NULL_BYTE '.' /* for query:key extractions */
 
 enum {
-  VARMODIFIER_URLDECODED = 1 << 1,
+  VARMODIFIER_URLENCODED = 1 << 1,
   VARMODIFIER_DEFAULT    = 1 << 2,
   VARMODIFIER_PUNY       = 1 << 3,
 };
@@ -523,8 +523,8 @@ static CURLUcode geturlpart(struct option *o, int modifiers, CURLU *uh,
                        CURLU_PUNYCODE : 0)|
 #endif
                       CURLU_NON_SUPPORT_SCHEME|
-                      ((modifiers & VARMODIFIER_URLDECODED) ?
-                       CURLU_URLDECODE : 0));
+                      ((modifiers & VARMODIFIER_URLENCODED) ?
+                       0 :CURLU_URLDECODE));
 }
 
 static void showurl(FILE *stream, struct option *o, int modifiers,
@@ -580,7 +580,7 @@ static void get(struct option *op, CURLU *uh)
 
         /* {path} {:path} */
         if(*ptr == ':') {
-          mods |= VARMODIFIER_URLDECODED;
+          mods |= VARMODIFIER_URLENCODED;
           ptr++;
         }
         vlen = end - ptr;
@@ -598,12 +598,12 @@ static void get(struct option *op, CURLU *uh)
             /* {query: or {query-all: */
             if(!strncmp(ptr, "query-all:", cl - ptr + 1)) {
               showqkey(stream, cl + 1, end - cl - 1,
-                       (mods & VARMODIFIER_URLDECODED) == 0, true);
+                       (mods & VARMODIFIER_URLENCODED) == 0, true);
             }
             else if(!strncmp(ptr, "query:", cl - ptr + 1)) {
               isquery = true;
               showqkey(stream, cl + 1, end - cl - 1,
-                       (mods & VARMODIFIER_URLDECODED) == 0, false);
+                       (mods & VARMODIFIER_URLENCODED) == 0, false);
             }
             else {
               /* syntax error */


### PR DESCRIPTION
I accidentally implemented {:component} backwards in https://github.com/curl/trurl/commit/5bc344a704dad9413b9ff2406c163fb471f8e7be

Oops :)

This also caused URL parts in the json output to be urlencoded instead of urldecoded, since code is shared.

---

One of the reason we split URL parts into a separate object was to allow users to apply transformations on a part of the URL using a jq command that maps the parts object to a trurl command that constructs the new modified URL, e.g. like so:
```sh
trurl --json --url "$url" |
jq -r '
  .[].parts |
  (.path | values) |= ascii_upcase |# uppercase the path if it present
  @sh "trurl \([ to_entries[] | "-s", "\(.key)=\(.value)"])"
' |
sh
```

But unfortunately, since the parts are urldecoded, this can't work.

libcurl, intead of returning a URL encoded part even if CURLU_URLDECODE is used like it does for CURLUPART_URL, when you request
```c
  curl_url_get(uh, CURLUPART_QUERY, &query, CURLU_URLDECODE)
```
returns the URL decoded version of the entire query string which is pretty much useless.

`?a%26b&a&b` becomes `?a&b&a&b` which is completely different, so that jq pipeline will run a command that won't reparse the query correctly. And there is not much it can do about that.

To fix this inconvenience, I suggest to add a --urlencode option that works like --punycode and --default-port, and makes {path} behave like {:path} by default (and consequently causes URL parts in the JSON output to be urlencoded).

Now users should be able to just use `--urlencode --json` instead of just `--json`, and `"-s", "\(.key):=\(.value)]"` instead of `"-s", "\(.key)=\(.value)]"` or `"-s", "\(.key):=\(.value | @uri)]"`, and that pipeline should work fine.

I also added tests to verify that the pipeline actually works.

And I also mentioned in the manual that the host will be punycoded in the json output if --punycode is used, which was previously not documented.