### PR TITLE
introduce CI job to run codespell

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,16 @@
+name: "Codespell"
+on: [push, pull_request]
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: install codespell
+      run: |
+        sudo apt-get update
+        sudo apt-get install codespell
+
+    - name: Perform spelling checks
+      run: codespell README.md RELEASE-NOTES trurl.c CONTRIBUTING.md trurl.1 trurl.c

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -19,7 +19,7 @@ Bugfixes since previous release
  o send -h output to stdout, not stderr
  o trurl.1: add an example using --iterate
  o trurl.1: document the JSON output format
- o use curl_url_cleanup() insted of curl_free()
+ o use curl_url_cleanup() instead of curl_free()
 
 Contributors to this release:
 


### PR DESCRIPTION
I dont know what the policy is, just a little codespell CI workflow (for all branches, though) on files where it makes sense to have some simple spelling checks in place :-)

Running codespell is part of the Debian QA process and common QA tools such as lintian will complain if manpages etc contain typos/spelling issues, so instead of opening a pull request each time i encounter one it may make sense to run this proactively.