### PR TITLE
Clean up whitespace, spelling/grammar, unused things, scope, shadowing, checks, file opens

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,24 +33,24 @@ jobs:
         language: ['cpp', 'python']
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
 
-    - name: install libcurl
-      run: |
-        sudo apt-get update
-        sudo apt-get install libcurl4-openssl-dev
+      - name: install libcurl
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev
 
-    - name: build
-      run: make
+      - name: build
+        run: make
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
-  
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
   analyze:
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'python' ]
+        language: ['cpp', 'python']
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -4,13 +4,13 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: install codespell
-      run: |
-        sudo apt-get update
-        sudo apt-get install codespell
+      - name: install codespell
+        run: |
+          sudo apt-get update
+          sudo apt-get install codespell
 
-    - name: Perform spelling checks
-      run: codespell README.md RELEASE-NOTES trurl.c CONTRIBUTING.md trurl.1 trurl.c
+      - name: Perform spelling checks
+        run: codespell README.md RELEASE-NOTES trurl.c CONTRIBUTING.md trurl.1 trurl.c

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,4 @@ jobs:
           sudo apt-get install codespell
 
       - name: Perform spelling checks
-        run: codespell README.md RELEASE-NOTES trurl.c CONTRIBUTING.md trurl.1 trurl.c
+        run: codespell README.md RELEASE-NOTES CONTRIBUTING.md trurl.1 trurl.c

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,36 +13,36 @@ jobs:
     strategy:
       matrix:
         build:
-        - name: default
-          install_packages: valgrind
-          test: test-memory
-        - name: clang sanitizers
-          install_packages: clang
-          test: test
-          make_opts: >
-            CC=clang
-            CFLAGS="-fsanitize=address,undefined,signed-integer-overflow -Wformat -Werror=format-security -Werror=array-bounds -g"
-            LDFLAGS="-fsanitize=address,undefined,signed-integer-overflow -g"
+          - name: default
+            install_packages: valgrind
+            test: test-memory
+          - name: clang sanitizers
+            install_packages: clang
+            test: test
+            make_opts: >
+              CC=clang
+              CFLAGS="-fsanitize=address,undefined,signed-integer-overflow -Wformat -Werror=format-security -Werror=array-bounds -g"
+              LDFLAGS="-fsanitize=address,undefined,signed-integer-overflow -g"
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: install libcurl
-      run: |
-        sudo apt-get update
-        sudo apt-get install libcurl4-openssl-dev ${{ matrix.build.install_packages }}
+      - name: install libcurl
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev ${{ matrix.build.install_packages }}
 
-    - name: code style check
-      run: make checksrc
+      - name: code style check
+        run: make checksrc
 
-    - name: make
-      run: make ${{ matrix.build.make_opts }}
+      - name: make
+        run: make ${{ matrix.build.make_opts }}
 
-    - name: sanity test
-      run: ./trurl -v
+      - name: sanity test
+        run: ./trurl -v
 
-    - name: test
-      run: make ${{matrix.build.test}}
+      - name: test
+        run: make ${{matrix.build.test}}
 
   cygwin:
     runs-on: windows-latest

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
   ubuntu:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,39 @@
-# Contributing to trurl 
+# Contributing to trurl
 This document is intended to provide a framework for contributing to trurl. This document will go over requesting new features, fixing existing bugs and effectively
-using the internal tooling to help PRs merge quickly. 
+using the internal tooling to help PRs merge quickly.
 
 ## Opening an issue
-trurl uses GitHubs issue tracking to track upcoming work. If you have a feature you want to add or find a bug simply open an issue in the 
-[issues tab](https://github.com/curl/trurl/issues). Briefly describe the feature you are requesting and why you think it may be valuable for trurl. If you are 
-reporting a bug be prepared for questions as we will want to reproduce it locally. In general providing the output of `trurl --version` along with the operating 
-system / Distro you are running is a good starting point. 
+trurl uses GitHubs issue tracking to track upcoming work. If you have a feature you want to add or find a bug simply open an issue in the
+[issues tab](https://github.com/curl/trurl/issues). Briefly describe the feature you are requesting and why you think it may be valuable for trurl. If you are
+reporting a bug be prepared for questions as we will want to reproduce it locally. In general providing the output of `trurl --version` along with the operating
+system / Distro you are running is a good starting point.
 
 ## Writing a good PR
 trurl is a relatively straightforward code base, so it is best to keep your PRs straightforward as well. Avoid trying to fix many bugs in one PR, and instead
-use many smaller PRs as this avoids potential conflicts when merging. trurl is written in C and uses the [curl code style](https://curl.se/dev/code-style.html). 
-PRs that do not follow to code style will not be merged in. 
+use many smaller PRs as this avoids potential conflicts when merging. trurl is written in C and uses the [curl code style](https://curl.se/dev/code-style.html).
+PRs that do not follow to code style will not be merged in.
 
-trurl is in its early stages, so it's important to open a PR against a recent version of the source code, as a lot can change over a few days. 
-Preferably you would open a PR against the most recent commit in master. 
+trurl is in its early stages, so it's important to open a PR against a recent version of the source code, as a lot can change over a few days.
+Preferably you would open a PR against the most recent commit in master.
 
 If you are implementing a new feature, it must be submitted with tests and documentation. The process for writing tests is explained below in the tooling section. Documentation exists
-in two locations, the man page ([trurl.1](https://github.com/curl/trurl/blob/master/trurl.1)) and the help prompt when running `trurl -h`. Most documentation changes 
-will go in the man page, but if you add a new command line argument then it must be documented in the help page. 
+in two locations, the man page ([trurl.1](https://github.com/curl/trurl/blob/master/trurl.1)) and the help prompt when running `trurl -h`. Most documentation changes
+will go in the man page, but if you add a new command line argument then it must be documented in the help page.
 
-It is also important to be prepared for feedback on your PR and adjust it promptly. 
+It is also important to be prepared for feedback on your PR and adjust it promptly.
 
 
 ## Tooling
-The trurl repository has a few small helper tools to make development easier. 
+The trurl repository has a few small helper tools to make development easier.
 
-**checksrc.pl** is used to ensure the code style is correct. It accepts C files as command line arguments, and returns nothing if the code style is valid. If the 
+**checksrc.pl** is used to ensure the code style is correct. It accepts C files as command line arguments, and returns nothing if the code style is valid. If the
 code style is incorrect, checksrc.pl will provide the line the error is on and a brief description of what is wrong. You may run `make checksrc` to scan the entire
-repository for style compliance. 
+repository for style compliance.
 
-**test.py** is used to run automated tests for trurl. It loads in tests from `test.json` (described below) and reports the number of tests passed. You may specify 
+**test.py** is used to run automated tests for trurl. It loads in tests from `test.json` (described below) and reports the number of tests passed. You may specify
 the tests to run by passing a list of comma-separated numbers as command line arguments, such as `4,8,15,16,23,42` Note there is no space between the numbers. `test.py`
 may also use valgrind to test for memory errors by passing `--with-valgrind` as a command line argument, it should be noted that this may take a while to run all the tests.
-`test.py` will also skip tests that require a specific curl runtime or buildtime. 
+`test.py` will also skip tests that require a specific curl runtime or buildtime.
 
 ### Adding tests
 tests are located in [tests.json](https://github.com/curl/trurl/blob/master/tests.json). This file is an array of json objects when outline an input and what the expected
@@ -71,7 +71,7 @@ output should be. Below is a simple example of a single test:
         }
     }
 ```
-trurl may also return json. It you are adding a test that returns json to stdout, write the json directly instead of a string in the examples above. Below is an example 
+trurl may also return json. It you are adding a test that returns json to stdout, write the json directly instead of a string in the examples above. Below is an example
 of what stdout should be if it is a json test, where `"input"` is what trul accepts from the command line and `"expected"` is what trurl should return.
 ```json
 "expected": {
@@ -93,6 +93,6 @@ of what stdout should be if it is a json test, where `"input"` is what trul acce
 ```
 
 # Tips to make opening a PR easier
-- Run `make checksrc` and `make test-memory` locally before opening a PR. These ran automatically when a PR is opened so you might as well make sure they pass before-hand.  
+- Run `make checksrc` and `make test-memory` locally before opening a PR. These ran automatically when a PR is opened so you might as well make sure they pass before-hand.
 - Update the man page and the help prompt accordingly. Documentation is annoying but if everyone writes a little it's not bad.
 - Add tests to cover new features or the bug you fixed.

--- a/checksrc.pl
+++ b/checksrc.pl
@@ -531,7 +531,7 @@ sub scanfile {
             }
             elsif(($first eq "*") && ($word !~ /(for|if|while|switch)/)) {
                 # A "(*" beginning makes the space OK because it wants to
-                # allow funcion pointer declared
+                # allow function pointer declared
             }
             elsif($1 =~ / *typedef/) {
                 # typedefs can use space-paren
@@ -883,7 +883,7 @@ sub scanfile {
         checkwarn("COPYRIGHT", 1, 0, $file, "", "Missing copyright statement", 1);
     }
 
-    # COPYRIGHTYEAR is a extended warning so we must first see if it has been
+    # COPYRIGHTYEAR is an extended warning so we must first see if it has been
     # enabled in .checksrc
     if(defined($warnings{"COPYRIGHTYEAR"})) {
         # The check for updated copyrightyear is overly complicated in order to

--- a/checksrc.pl
+++ b/checksrc.pl
@@ -98,13 +98,13 @@ my %warnings = (
     );
 
 sub readskiplist {
-    open(W, "<$dir/checksrc.skip") or return;
-    my @all=<W>;
+    open(my $W, '<', "$dir/checksrc.skip") or return;
+    my @all=<$W>;
     for(@all) {
         $windows_os ? $_ =~ s/\r?\n$// : chomp;
         $skiplist{$_}=1;
     }
-    close(W);
+    close($W);
 }
 
 # Reads the .checksrc in $dir for any extended warnings to enable locally.
@@ -380,7 +380,7 @@ sub scanfile {
     my $l = "";
     my $prep = 0;
     my $prevp = 0;
-    open(R, "<$file") || die "failed to open $file";
+    open(my $R, '<', $file) || die "failed to open $file";
 
     my $incomment=0;
     my @copyright=();
@@ -388,7 +388,7 @@ sub scanfile {
     checksrc_clear(); # for file based ignores
     accept_violations();
 
-    while(<R>) {
+    while(<$R>) {
         $windows_os ? $_ =~ s/\r?\n$// : chomp;
         my $l = $_;
         my $ol = $l; # keep the unmodified line for error reporting
@@ -933,7 +933,7 @@ sub scanfile {
 
     checksrc_endoffile($file);
 
-    close(R);
+    close($R);
 
 }
 

--- a/test.py
+++ b/test.py
@@ -78,7 +78,8 @@ class TestCase:
         return True
 
     def test(self):
-        # return true only if stdout, stderr and errorcode is equal to the ones found in testfile
+        # return true only if stdout, stderr and errorcode
+        # is equal to the ones found in testfile
         self.testPassed = all(
             testComponent(asdict(self.commandOutput)[k], exp)
             for k, exp in self.expected.items())

--- a/test.py
+++ b/test.py
@@ -63,7 +63,7 @@ class TestCase:
         )
 
         if isinstance(self.expected["stdout"], list):
-            # if we dont expect string, parse to json
+            # if we don't expect string, parse to json
             try:
                 stdout = json.loads(output.stdout)
             except json.decoder.JSONDecodeError:
@@ -79,7 +79,7 @@ class TestCase:
 
     def test(self):
         # return true only if stdout, stderr and errorcode
-        # is equal to the ones found in testfile
+        # are equal to the ones found in the testfile
         self.testPassed = all(
             testComponent(asdict(self.commandOutput)[k], exp)
             for k, exp in self.expected.items())

--- a/test.py
+++ b/test.py
@@ -2,7 +2,6 @@
 
 import sys
 from os import getcwd, path
-import re
 import json
 import shlex
 from subprocess import PIPE, run

--- a/tests.json
+++ b/tests.json
@@ -1656,7 +1656,7 @@
     {
         "input": {
             "arguments": [
-                "imaps://user:pasword;crazy@[ff00::1234%hello]:1234/path?a=b&c=d#fragment",
+                "imaps://user:password;crazy@[ff00::1234%hello]:1234/path?a=b&c=d#fragment",
                 "--json"
             ]
         },
@@ -1664,11 +1664,11 @@
             "returncode": 0,
             "stdout": [
                 {
-                    "url": "imaps://user:pasword;crazy@[ff00::1234%25hello]:1234/path?a=b&c=d#fragment",
+                    "url": "imaps://user:password;crazy@[ff00::1234%25hello]:1234/path?a=b&c=d#fragment",
                     "parts": {
                         "scheme": "imaps",
                         "user": "user",
-                        "password": "pasword",
+                        "password": "password",
                         "options": "crazy",
                         "host": "[ff00::1234]",
                         "port": "1234",

--- a/trurl.c
+++ b/trurl.c
@@ -258,7 +258,6 @@ struct option {
   bool no_guess_scheme;
   bool urlencode;
   bool end_of_options;
-  unsigned char output;
 
   /* -- stats -- */
   unsigned int urls;

--- a/trurl.c
+++ b/trurl.c
@@ -732,8 +732,8 @@ static unsigned int set(CURLU *uh,
   unsigned int mask = 0;
   for(node =  o->set_list; node; node = node->next) {
     const struct var *v;
-    char *set = node->data;
-    v = setone(uh, set);
+    char *setline = node->data;
+    v = setone(uh, setline);
     if(v) {
       if(mask & (1 << v->part))
         errorf(ERROR_SET, "duplicate --set for component %s", v->name);

--- a/trurl.c
+++ b/trurl.c
@@ -1131,7 +1131,7 @@ static void singleurl(struct option *o,
                      urlencode ? "" : ":",
                      (int)wlen, w);
       setone(uh, iterbuf);
-      if(iter && iter->next) {
+      if(iter->next) {
         struct iterinfo info;
         memset(&info, 0, sizeof(info));
         info.uh = uh;

--- a/trurl.c
+++ b/trurl.c
@@ -998,17 +998,15 @@ static void extractqpairs(CURLU *uh, struct option *o)
 static void qpair2query(CURLU *uh, struct option *o)
 {
   int i;
-  int rc;
   char *nq = NULL;
-  char *oldnq;
   for(i = 0; i<nqpairs; i++) {
-    oldnq = nq;
+    char *oldnq = nq;
     nq = curl_maprintf("%s%s%s", nq?nq:"",
                        (nq && *nq && *qpairs[i])? o->qsep: "", qpairs[i]);
     curl_free(oldnq);
   }
   if(nq) {
-    rc = curl_url_set(uh, CURLUPART_QUERY, nq, 0);
+    int rc = curl_url_set(uh, CURLUPART_QUERY, nq, 0);
     if(rc)
       warnf("internal problem");
   }
@@ -1071,7 +1069,6 @@ static void singleurl(struct option *o,
     }
   }
   do {
-    char iterbuf[1024];
     struct curl_slist *p;
     bool url_is_invalid = false;
     unsigned setmask = 0;
@@ -1080,6 +1077,7 @@ static void singleurl(struct option *o,
     setmask = set(uh, o);
 
     if(iter) {
+      char iterbuf[1024];
       /* "part=item1 item2 item2" */
       const char *part;
       size_t plen;


### PR DESCRIPTION
- Remove trailing whitespace
- Remove whitespace from arrays
- Split up a long line
- Fix indentation
- Uppercase the manual page document title
- Fix typos
- Remove an unused import
- Remove unused struct member
- Reduce scope of some variables
- Remove unnecessary pointer check
- Avoid using the name of a function for a variable within that function
- Modernise Perl file open calls
- Only check trurl.c for spelling errors once
