### PR TITLE
trurl: accept \* as a trim name to trim a literal asterisk name

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2098,5 +2098,20 @@
                 }
             ]        
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--url",
+                "https://curl.se/we/are.html?*=moo&user=many#more",
+                "--trim",
+                "query=\\*"
+            ]
+        },
+        "expected": {
+            "stdout": "https://curl.se/we/are.html?user=many#more\n",
+            "stderr": "",
+            "returncode": 0
+        }
     }
 ]

--- a/trurl.1
+++ b/trurl.1
@@ -224,6 +224,9 @@ Trims data off a component. Currently this can only trim a query component.
 "what" is specified as a full word or as a word prefix (using a single
 trailing asterisk ('*')) which makes trurl remove the tuples from the query
 string that match the instruction.
+
+To match a literal trailing asterisk instead of using a wildcard, escape it with
+a backslash in front of it. Like "\\*".
 .IP "-v, --version"
 Show version information and exit.
 .IP "--verify"


### PR DESCRIPTION
Added test case. Added docs.

Reported-by: Anselm Schüler
Fixes #227