### PR TITLE
General Cleanup

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -448,13 +448,11 @@ static int getarg(struct option *o,
     urlfile(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-a", flag, arg) ||
-          checkoptarg("--append", flag, arg)) {
+  else if(checkoptarg("-a", flag, arg) || checkoptarg("--append", flag, arg)) {
     appendadd(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-s", flag, arg) ||
-          checkoptarg("--set", flag, arg)) {
+  else if(checkoptarg("-s", flag, arg) || checkoptarg("--set", flag, arg)) {
     setadd(o, arg);
     *usedarg = true;
   }
@@ -480,8 +478,7 @@ static int getarg(struct option *o,
     trimadd(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-g", flag, arg) ||
-          checkoptarg("--get", flag, arg)) {
+  else if(checkoptarg("-g", flag, arg) || checkoptarg("--get", flag, arg)) {
     if(o->format)
       errorf(ERROR_FLAG, "only one --get is supported");
     if(o->jsonout)


### PR DESCRIPTION
`struct option *` was referred to as both `o` and `op` this patch makes it so all occurrences of it to `o`. I also removed some unneeded newlines in if statements. 