### PR TITLE
Trurl_errorf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@
 
 TARGET = trurl
 OBJS = trurl.o
-LDLIBS = $$(~/.curl/bin/curl-config --libs)
-CFLAGS += $$(~/.curl/bin/curl-config --cflags) -W -Wall -Wshadow -Werror -pedantic -g -std=gnu99
+LDLIBS = $$(curl-config --libs)
+CFLAGS += $$(curl-config --cflags) -W -Wall -Wshadow -Werror -pedantic -g -std=gnu99
 MANUAL = trurl.1
 
 PREFIX ?= /usr/local

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@
 
 TARGET = trurl
 OBJS = trurl.o
-LDLIBS = $$(curl-config --libs)
-CFLAGS += $$(curl-config --cflags) -W -Wall -Wshadow -Werror -pedantic -g -std=gnu99
+LDLIBS = $$(~/.curl/bin/curl-config --libs)
+CFLAGS += $$(~/.curl/bin/curl-config --cflags) -W -Wall -Wshadow -Werror -pedantic -g -std=gnu99
 MANUAL = trurl.1
 
 PREFIX ?= /usr/local

--- a/trurl.c
+++ b/trurl.c
@@ -453,11 +453,13 @@ static int getarg(struct option *o,
     urlfile(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-a", flag, arg) || checkoptarg("--append", flag, arg)) {
+  else if(checkoptarg(o, "-a", flag, arg) ||
+          checkoptarg(o, "--append", flag, arg)) {
     appendadd(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-s", flag, arg) || checkoptarg("--set", flag, arg)) {
+  else if(checkoptarg(o, "-s", flag, arg) ||
+          checkoptarg(o, "--set", flag, arg)) {
     setadd(o, arg);
     *usedarg = true;
   }
@@ -484,7 +486,8 @@ static int getarg(struct option *o,
     trimadd(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-g", flag, arg) || checkoptarg("--get", flag, arg)) {
+  else if(checkoptarg(o, "-g", flag, arg) ||
+          checkoptarg(o, "--get", flag, arg)) {
     if(o->format)
       errorf(o, ERROR_FLAG, "only one --get is supported");
     if(o->jsonout)
@@ -516,12 +519,12 @@ static int getarg(struct option *o,
     o->keep_port = true;
   else if(!strcmp("--punycode", flag)) {
     if(o->puny2idn)
-      errorf(ERROR_FLAG, "--punycode is mutually exclusive with --as-idn");
+      errorf(o, ERROR_FLAG, "--punycode is mutually exclusive with --as-idn");
     o->punycode = true;
   }
   else if(!strcmp("--as-idn", flag)) {
     if(o->punycode)
-      errorf(ERROR_FLAG, "--as-idn is mutually exclusive with --punycode");
+      errorf(o, ERROR_FLAG, "--as-idn is mutually exclusive with --punycode");
     o->puny2idn = true;
   }
   else if(!strcmp("--no-guess-scheme", flag))
@@ -675,13 +678,13 @@ static void get(struct option *o, CURLU *uh)
             mods |= VARMODIFIER_DEFAULT;
           else if(!strncmp(ptr, "puny:", cl - ptr + 1)) {
             if(mods & VARMODIFIER_PUNY2IDN)
-              errorf(ERROR_GET,
+              errorf(o, ERROR_GET,
                      "puny modifier is mutually exclusive with idn");
             mods |= VARMODIFIER_PUNY;
           }
           else if(!strncmp(ptr, "idn:", cl - ptr + 1)) {
             if(mods & VARMODIFIER_PUNY)
-              errorf(ERROR_GET,
+              errorf(o, ERROR_GET,
                      "idn modifier is mutually exclusive with puny");
             mods |= VARMODIFIER_PUNY2IDN;
           }

--- a/trurl.c
+++ b/trurl.c
@@ -1368,6 +1368,8 @@ static void singleurl(struct option *o,
           if(!rc)
             curl_free(nurl);
           else {
+            if(o->verify) /* only clean up if we're exiting */
+              curl_url_cleanup(uh);
             VERIFY(o, ERROR_BADURL, "url became invalid");
             url_is_invalid = true;
           }

--- a/trurl.c
+++ b/trurl.c
@@ -309,6 +309,7 @@ static void errorf(struct option *o, int exit_code, char *fmt, ...)
   fputs("\n" ERROR_PREFIX "Try " PROGNAME " -h for help\n", stderr);
   va_end(ap);
   trurl_cleanup_options(o);
+  curl_global_cleanup();
   exit(exit_code);
 }
 
@@ -1347,12 +1348,16 @@ static void singleurl(struct option *o,
       char *ourl = NULL;
       CURLUcode rc = curl_url_get(uh, CURLUPART_URL, &ourl, 0);
       if(rc) {
+        if(o->verify) /* only clean up if we're exiting */
+          curl_url_cleanup(uh);
         VERIFY(o, ERROR_URL, "not enough input for a URL");
         url_is_invalid = true;
       }
       else {
         rc = seturl(o, uh, ourl);
         if(rc) {
+          if(o->verify) /* only clean up if we're exiting */
+            curl_url_cleanup(uh);
           VERIFY(o, ERROR_BADURL, "%s [%s]", curl_url_strerror(rc),
                  ourl);
           url_is_invalid = true;

--- a/trurl.c
+++ b/trurl.c
@@ -786,7 +786,7 @@ static void get(struct option *o, CURLU *uh)
 }
 
 static const struct var *setone(CURLU *uh, const char *setline,
-                                const struct option *o)
+                                struct option *o)
 {
   char *ptr = strchr(setline, '=');
   const struct var *v = NULL;

--- a/trurl.c
+++ b/trurl.c
@@ -450,11 +450,13 @@ static int getarg(struct option *o,
     urlfile(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-a", flag, arg) || checkoptarg("--append", flag, arg)) {
+  else if(checkoptarg("-a", flag, arg) ||
+          checkoptarg("--append", flag, arg)) {
     appendadd(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-s", flag, arg) || checkoptarg("--set", flag, arg)) {
+  else if(checkoptarg("-s", flag, arg) ||
+          checkoptarg("--set", flag, arg)) {
     setadd(o, arg);
     *usedarg = true;
   }
@@ -480,7 +482,8 @@ static int getarg(struct option *o,
     trimadd(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-g", flag, arg) || checkoptarg("--get", flag, arg)) {
+  else if(checkoptarg("-g", flag, arg) ||
+          checkoptarg("--get", flag, arg)) {
     if(o->format)
       errorf(ERROR_FLAG, "only one --get is supported");
     if(o->jsonout)

--- a/trurl.c
+++ b/trurl.c
@@ -450,13 +450,11 @@ static int getarg(struct option *o,
     urlfile(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-a", flag, arg) ||
-          checkoptarg("--append", flag, arg)) {
+  else if(checkoptarg("-a", flag, arg) || checkoptarg("--append", flag, arg)) {
     appendadd(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-s", flag, arg) ||
-          checkoptarg("--set", flag, arg)) {
+  else if(checkoptarg("-s", flag, arg) || checkoptarg("--set", flag, arg)) {
     setadd(o, arg);
     *usedarg = true;
   }
@@ -482,8 +480,7 @@ static int getarg(struct option *o,
     trimadd(o, arg);
     *usedarg = true;
   }
-  else if(checkoptarg("-g", flag, arg) ||
-          checkoptarg("--get", flag, arg)) {
+  else if(checkoptarg("-g", flag, arg) || checkoptarg("--get", flag, arg)) {
     if(o->format)
       errorf(ERROR_FLAG, "only one --get is supported");
     if(o->jsonout)

--- a/trurl.c
+++ b/trurl.c
@@ -290,18 +290,19 @@ int nqpairs; /* how many is stored */
 
 static void trurl_cleanup_options(struct option *o)
 {
-  if(!o) return;
-  if(o->url_list) 
+  if(!o)
+    return;
+  if(o->url_list)
     curl_slist_free_all(o->url_list);
-  if(o->set_list) 
+  if(o->set_list)
     curl_slist_free_all(o->set_list);
-  if(o->iter_list) 
+  if(o->iter_list)
     curl_slist_free_all(o->iter_list);
-  if(o->append_query) 
+  if(o->append_query)
     curl_slist_free_all(o->append_query);
-  if(o->trim_list) 
+  if(o->trim_list)
     curl_slist_free_all(o->trim_list);
-  if(o->append_path) 
+  if(o->append_path)
     curl_slist_free_all(o->append_path);
 }
 
@@ -480,7 +481,8 @@ static int getarg(struct option *o,
     if(o->qsep)
       trurl_errorf(o, ERROR_FLAG, "only one --query-separator is supported");
     if(strlen(arg) != 1)
-      trurl_errorf(o, ERROR_FLAG, "only single-letter query separators are supported");
+      trurl_errorf(o, ERROR_FLAG,
+                   "only single-letter query separators are supported");
     o->qsep = arg;
     *usedarg = true;
   }
@@ -492,7 +494,8 @@ static int getarg(struct option *o,
     if(o->format)
       trurl_errorf(o, ERROR_FLAG, "only one --get is supported");
     if(o->jsonout)
-      trurl_errorf(o, ERROR_FLAG, "--get is mututally exclusive with --json");
+      trurl_errorf(o, ERROR_FLAG,
+                   "--get is mututally exclusive with --json");
     o->format = arg;
     *usedarg = true;
   }
@@ -808,7 +811,8 @@ static const struct var *setone(CURLU *uh, const char *setline,
       found = true;
     }
     if(!found)
-      trurl_errorf(o, ERROR_SET, "unknown component: %.*s", (int)vlen, setline);
+      trurl_errorf(o, ERROR_SET,
+                   "unknown component: %.*s", (int)vlen, setline);
   }
   else
     trurl_errorf(o, ERROR_SET, "invalid --set syntax: %s", setline);
@@ -826,7 +830,8 @@ static unsigned int set(CURLU *uh,
     v = setone(uh, setline, o);
     if(v) {
       if(mask & (1 << v->part))
-        trurl_errorf(o, ERROR_SET, "duplicate --set for component %s", v->name);
+        trurl_errorf(o, ERROR_SET,
+                     "duplicate --set for component %s", v->name);
       mask |= (1 << v->part);
     }
   }
@@ -1260,11 +1265,13 @@ static void singleurl(struct option *o,
         }
         if(iinfo->varmask & (1<<v->part)) {
           curl_url_cleanup(uh);
-          trurl_errorf(o, ERROR_ITER, "duplicate component for iterate: %s", v->name);
+          trurl_errorf(o, ERROR_ITER,
+                       "duplicate component for iterate: %s", v->name);
         }
         if(setmask & (1 << v->part)) {
           curl_url_cleanup(uh);
-          trurl_errorf(o, ERROR_ITER, "duplicate --iterate and --set for component %s",
+          trurl_errorf(o, ERROR_ITER,
+                 "duplicate --iterate and --set for component %s",
                  v->name);
         }
       }


### PR DESCRIPTION
Added trurl_errorf which handles cleanup of `struct option` before exiting but after printing in case whats being printed must be cleaned up. It is based on #234 so that should be merged before this. Note that this (should) fix the two memory leaks discussed in #232  that were left over. 