### PR TITLE
trurl: add `--curl` to only count as valid URLs supported by libcurl

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2190,5 +2190,19 @@
             "returncode": 0,
             "stderr": ""
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--curl",
+                "--verify",
+                "foo://bar"
+            ]
+        },
+        "expected": {
+            "stdout": "",
+            "stderr": true,
+            "returncode": 9
+        }
     }
 ]


### PR DESCRIPTION
I would prefer that `trurl` rejected URLs with schemes not supported by libcurl when I use it in combination with `curl`.