### PR TITLE
Makefile: updates and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,14 @@
 
 TARGET = trurl
 OBJS = trurl.o
-LDLIBS = $$(curl-config --libs)
-CFLAGS += $$(curl-config --cflags) -W -Wall -Wshadow -Werror -pedantic -g -std=gnu99
+ifndef TRURL_IGNORE_CURL_CONFIG
+LDLIBS += $$(curl-config --libs)
+CFLAGS += $$(curl-config --cflags)
+endif
+CFLAGS += -W -Wall -Wshadow -Werror -pedantic
+ifndef NDEBUG
+CFLAGS += -g
+endif
 MANUAL = trurl.1
 
 PREFIX ?= /usr/local
@@ -38,7 +44,7 @@ PYTHON3 ?= python3
 $(TARGET): $(OBJS)
 	$(CC) $(OBJS) -o $(TARGET) $(LDLIBS) $(LDFLAGS)
 
-trurl.o:trurl.c version.h
+trurl.o: trurl.c version.h
 
 .PHONY: install
 install:


### PR DESCRIPTION
- add `TRURL_IGNORE_CURL_CONFIG` to avoid reading `curl-config`.
  This allows to specify curl bits manually without unexpectedly
  picking up system curl bits too.

- allow to disable debug info by passing `NDEBUG=1`.

- drop `-std=gnu99` from `CFLAGS`. This decision should be up to the
  builder, in sync with the curl (and its dependencies) linked to trurl.
  curl doesn't build with this option by default and mixing objects with
  different settings may break the ABI.

- accept `LDLIBS` from the environment.

- one whitespace tidy-up.

Closes #xxx
