### PR TITLE
enable more C compiler warnings and fix them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ LDLIBS += $$(curl-config --libs)
 CFLAGS += $$(curl-config --cflags)
 endif
 CFLAGS += -W -Wall -Wshadow -Werror -pedantic
+CFLAGS += -Wconversion -Wmissing-prototypes -Wwrite-strings -Wsign-compare -Wno-sign-conversion
 ifndef NDEBUG
 CFLAGS += -g
 endif


### PR DESCRIPTION
First I enabled all picky warnings from curl, then fixed all of them and
kept warning options enabled that needed fixing.

---

- [x] Needs rebase after merging #250.

