### PR TITLE
Makefile: pass `LDFLAGS` first, then `LDLIBS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ INSTALL ?= install
 PYTHON3 ?= python3
 
 $(TARGET): $(OBJS)
-	$(CC) $(OBJS) -o $(TARGET) $(LDLIBS) $(LDFLAGS)
+	$(CC) $(OBJS) -o $(TARGET) $(LDFLAGS) $(LDLIBS)
 
 trurl.o: trurl.c version.h
 


### PR DESCRIPTION
Some `LDFLAGS` are positional and affect how `LDLIBS` are interpreted.
Not a hard rule, but perhaps it's more usual to pass the libs last.

Ref: https://github.com/curl/curl-for-win/commit/764fa9b1db9dd531191563f36c82d75e1e53d823
