### PR TITLE
ci: build libcurl without http

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-dev-zero-imap-osnotls-osnoidn-nocurltool-win'
+          export CW_CONFIG='-dev-zero-imap-osnotls-osnoidn-nohttp-nocurltool-win'
           export CW_REVISION='${{ github.sha }}'
           . ./_versions.sh
           docker trust inspect --pretty "${DOCKER_IMAGE}"

--- a/tests.json
+++ b/tests.json
@@ -260,13 +260,14 @@
     {
         "input": {
             "arguments": [
-                "http://curl.se:22/",
+                "imap://curl.se:22/",
                 "-s",
-                "port=80"
+                "port=143"
             ]
         },
+        "required": ["imap-options"],
         "expected": {
-            "stdout": "http://curl.se/\n",
+            "stdout": "imap://curl.se/\n",
             "stderr": "",
             "returncode": 0
         }
@@ -323,13 +324,14 @@
             "arguments": [
                 "--default-port",
                 "--url",
-                "http://curl.se/we/are.html",
+                "imap://curl.se/we/are.html",
                 "--get",
                 "{port}"
             ]
         },
+        "required": ["imap-options"],
         "expected": {
-            "stdout": "80\n",
+            "stdout": "143\n",
             "stderr": "",
             "returncode": 0
         }
@@ -506,13 +508,14 @@
         "input": {
             "arguments": [
                 "--url",
-                "http://curl.se/we/are.html",
+                "imap://curl.se/we/are.html",
                 "-g",
                 "{default:port}"
             ]
         },
+        "required": ["imap-options"],
         "expected": {
-            "stdout": "80\n",
+            "stdout": "143\n",
             "stderr": "",
             "returncode": 0
         }
@@ -1716,14 +1719,15 @@
     {
         "input": {
             "arguments": [
-                "http://example.com/",
+                "imap://example.com/",
                 "--get",
                 "port: {port}, default:port: {default:port}"
             ]
         },
+        "required": ["imap-options"],
         "expected": {
             "returncode": 0,
-            "stdout": "port: , default:port: 80\n"
+            "stdout": "port: , default:port: 143\n"
         }
     },
     {


### PR DESCRIPTION
For even smaller trurl binaries, and faster builds with libcurl built
without http support.

Also move http/80 tests to imap/143 for default-port tests.
We need IMAP already for IMAP options support.

Also mark tests relying on IMAP default port to require libcurl with
IMAP enabled.

ARM64 `trurl.exe` sizes:
- Before: 465KB https://github.com/curl/trurl/actions/runs/6903445608
- After, no http: 324KB https://github.com/curl/trurl/actions/runs/6903509264
- no http, no unity: 245KB https://github.com/curl/trurl/actions/runs/6903576741
- no http, no imap, unity: 243KB https://github.com/curl/trurl/actions/runs/6906597033
- no http, no imap, no unity: 189KB https://github.com/curl/trurl/actions/runs/6903738976

Closes #255

---

Pending: https://github.com/curl/curl/pull/12343 [MERGED]
