### PR TITLE
fix copy-paste error in punycode macro

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -212,7 +212,7 @@ static void show_version(void)
 #endif
 
   fprintf(stdout, "features:");
-#ifdef SUPPORTS_PUNY2IDN
+#ifdef SUPPORTS_PUNYCODE
   if(supports_puny)
     fprintf(stdout, " punycode");
 #endif


### PR DESCRIPTION
Follow-up to bc67bb6056765b496580f661439fd3a9e6b26585