### PR TITLE
actually use the IMAP detection result to enable `imap-options`

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -235,7 +235,8 @@ static void show_version(void)
   fprintf(stdout, " normalize-ipv4");
 #endif
 #ifdef SUPPORTS_IMAP_OPTIONS
-  fprintf(stdout, " imap-options");
+  if(supports_imap)
+    fprintf(stdout, " imap-options");
 #endif
 #ifdef SUPPORTS_PUNY2IDN
   if(supports_puny)


### PR DESCRIPTION
Follow-up to 67d81bf931bd66edb9b65396d399a840482e2182