### PR TITLE
Added UTF-8 detection to test runner

### DIFF
--- a/test.py
+++ b/test.py
@@ -190,7 +190,7 @@ def main(argc, argv):
     if sys.platform == "win32" or sys.platform == "cygwin":
         baseCmd += ".exe"
 
-    with open(path.join(baseDir, TESTFILE), "r") as file:
+    with open(path.join(baseDir, TESTFILE), "r", encoding="utf-8") as file:
         allTests = json.load(file)
         testIndexesToRun = []
 

--- a/tests.json
+++ b/tests.json
@@ -1641,6 +1641,7 @@
             ]
         },
         "required": ["punycode"],
+        "encoding": "UTF-8",
         "expected": {
             "stderr": "",
             "returncode": 0,
@@ -1656,6 +1657,7 @@
             ]
         },
         "required": ["punycode"],
+        "encoding": "UTF-8",
         "expected": {
             "stderr": "",
             "returncode": 0,
@@ -1671,6 +1673,7 @@
             ]
         },
         "required": ["punycode"],
+        "encoding": "UTF-8",
         "expected": {
             "stderr": "",
             "returncode": 0,
@@ -2149,6 +2152,7 @@
             ]
         },
         "required": ["punycode2idn"],
+        "encoding": "UTF-8",
         "expected": {
             "stdout": "http://räksmörgås/\n",
             "stderr": "",
@@ -2165,6 +2169,7 @@
             ]
         },
         "required": ["punycode2idn"],
+        "encoding": "UTF-8",
         "expected": {
             "stdout": "räksmörgås\n",
             "stderr": "",
@@ -2181,6 +2186,7 @@
             ]
         },
         "required": ["punycode2idn"],
+        "encoding": "UTF-8",
         "expected": {
             "stdout": "http://xn-----/\n",
             "stderr": "",
@@ -2196,6 +2202,7 @@
             ]
         },
         "required": ["punycode2idn"],
+        "encoding": "UTF-8",
         "expected": {
             "stdout": "http://xn-----/\n",
             "stderr": "trurl note: Error converting url to IDN [Bad hostname]\n",


### PR DESCRIPTION
Adds the ability to skip tests that require UTF-8 encoding if the environment does not support UTF-8. It also cleaned up the feature checking logic.

Note: There is probably a much better way to do this, so feel free to leave suggestions.

fixes: #272