### PR TITLE
Allow trurl to read from stdin using pipes.

### DIFF
--- a/test.py
+++ b/test.py
@@ -98,7 +98,8 @@ class TestCase:
             cmd + args,
             stdout=PIPE, stderr=PIPE,
             encoding="utf-8",
-            input=self.stdin
+            shell=False,
+            input=self.stdin 
         )
 
         if isinstance(self.expected["stdout"], list):

--- a/test.py
+++ b/test.py
@@ -74,7 +74,7 @@ class TestCase:
         self.testIndex = testIndex
         self.runnerCmd = runnerCmd
         self.baseCmd = baseCmd
-        self.arguments = testCase["input"].get("arguments", [""])
+        self.arguments = testCase["input"]["arguments"]
         self.expected = testCase["expected"]
         self.commandOutput: CommandOutput = None
         self.testPassed: bool = False

--- a/test.py
+++ b/test.py
@@ -94,19 +94,12 @@ class TestCase:
             cmd = [VALGRINDTEST]
             args = VALGRINDARGS + [self.baseCmd] + self.arguments
 
-        if self.stdin:
-            output = run(
-                cmd + args,
-                stdout=PIPE, stderr=PIPE,
-                encoding="utf-8",
-                input=self.stdin 
-            )
-        else:
-            output = run(
-                cmd + args,
-                stdout=PIPE, stderr=PIPE,
-                encoding="utf-8",
-            )
+        output = run(
+            cmd + args,
+            stdout=PIPE, stderr=PIPE,
+            encoding="utf-8",
+        )
+
         if isinstance(self.expected["stdout"], list):
             # if we don't expect string, parse to json
             try:

--- a/test.py
+++ b/test.py
@@ -98,6 +98,7 @@ class TestCase:
             cmd + args,
             stdout=PIPE, stderr=PIPE,
             encoding="utf-8",
+            input=self.stdin
         )
 
         if isinstance(self.expected["stdout"], list):

--- a/test.py
+++ b/test.py
@@ -78,7 +78,7 @@ class TestCase:
         self.expected = testCase["expected"]
         self.commandOutput: CommandOutput = None
         self.testPassed: bool = False
-        self.stdin = testCase["input"].get("stdin", None)
+        # self.stdin = testCase["input"].get("stdin", None)
 
     def runCommand(self, cmdfilter: Optional[str], runWithValgrind: bool):
         # Skip test if none of the arguments contain the keyword

--- a/test.py
+++ b/test.py
@@ -74,10 +74,11 @@ class TestCase:
         self.testIndex = testIndex
         self.runnerCmd = runnerCmd
         self.baseCmd = baseCmd
-        self.arguments = testCase["input"]["arguments"]
+        self.arguments = testCase["input"].get("arguments", [""])
         self.expected = testCase["expected"]
         self.commandOutput: CommandOutput = None
         self.testPassed: bool = False
+        self.stdin = testCase["input"].get("stdin", None)
 
     def runCommand(self, cmdfilter: Optional[str], runWithValgrind: bool):
         # Skip test if none of the arguments contain the keyword
@@ -96,7 +97,8 @@ class TestCase:
         output = run(
             cmd + args,
             stdout=PIPE, stderr=PIPE,
-            encoding="utf-8"
+            encoding="utf-8",
+            input=self.stdin
         )
 
         if isinstance(self.expected["stdout"], list):

--- a/test.py
+++ b/test.py
@@ -97,8 +97,7 @@ class TestCase:
         output = run(
             cmd + args,
             stdout=PIPE, stderr=PIPE,
-            encoding="utf-8",
-            input=self.stdin
+            encoding="utf-8"
         )
 
         if isinstance(self.expected["stdout"], list):

--- a/test.py
+++ b/test.py
@@ -94,14 +94,19 @@ class TestCase:
             cmd = [VALGRINDTEST]
             args = VALGRINDARGS + [self.baseCmd] + self.arguments
 
-        output = run(
-            cmd + args,
-            stdout=PIPE, stderr=PIPE,
-            encoding="utf-8",
-            shell=False,
-            input=self.stdin 
-        )
-
+        if self.stdin:
+            output = run(
+                cmd + args,
+                stdout=PIPE, stderr=PIPE,
+                encoding="utf-8",
+                input=self.stdin 
+            )
+        else:
+            output = run(
+                cmd + args,
+                stdout=PIPE, stderr=PIPE,
+                encoding="utf-8",
+            )
         if isinstance(self.expected["stdout"], list):
             # if we don't expect string, parse to json
             try:

--- a/tests.json
+++ b/tests.json
@@ -2433,5 +2433,44 @@
             "stderr": "",
             "stdout": "http://google.com/\n"
         }
+  },
+  {
+    "input": {
+        "stdin": "google.com",
+        "arguments": ["--get", "{path}"]
+    },
+    "expected": {
+        "returncode": 0,
+        "stderr": "",
+        "stdout": "/\n"
+    }
+  },
+  {
+    "input": {
+        "stdin": "http://example.org/?quest=best",
+        "arguments": [
+            "--replace",
+            "quest=%00",
+            "--json"
+        ]
+    },
+    "expected": {
+        "stdout": [{
+            "url": "http://example.org/?quest=%00",
+            "parts": {
+                "scheme": "http",
+                "host": "example.org",
+                "path": "/"
+            },
+            "params": [
+                {
+                    "key": "quest",
+                    "value": "\u0000"
+                }
+            ]
+        }],
+        "stderr": "",
+        "returncode": 0
+    }
   }
 ]

--- a/tests.json
+++ b/tests.json
@@ -2425,17 +2425,6 @@
       }
   },
   {
-        "input": {
-            "stdin": "google.com",
-            "arguments": [""]
-        },
-        "expected": {
-            "returncode": 0,
-            "stderr": "",
-            "stdout": "http://google.com/\n"
-        }
-  },
-  {
     "input": {
         "stdin": "google.com",
         "arguments": ["--get", "{path}"]

--- a/tests.json
+++ b/tests.json
@@ -2423,5 +2423,15 @@
               }
           ]
       }
+  },
+  {
+        "input": {
+            "stdin": "google.com"
+        },
+        "expected": {
+            "returncode": 0,
+            "stderr": "",
+            "stdout": "http://google.com/\n"
+        }
   }
 ]

--- a/tests.json
+++ b/tests.json
@@ -2426,7 +2426,8 @@
   },
   {
         "input": {
-            "stdin": "google.com"
+            "stdin": "google.com",
+            "arguments": [""]
         },
         "expected": {
             "returncode": 0,

--- a/trurl.1
+++ b/trurl.1
@@ -84,7 +84,8 @@ scheme, this option is pretty much ignored unless one of \fI--get\fP,
 \fI--json\fP, and \fI--keep-port\fP is not also specified.
 .IP "-f, --url-file [file name]"
 Read URLs to work on from the given file. Use the file name "-" (a single
-minus) to tell trurl to read the URLs from stdin.
+minus) to tell trurl to read the URLs from stdin, or you may use pipes to feed 
+urls to trurl.
 
 Each line needs to be a single valid URL. trurl will remove one carriage return
 character at the end of the line if present, trim off all the trailing space and

--- a/trurl.c
+++ b/trurl.c
@@ -1580,6 +1580,7 @@ int main(int argc, const char **argv)
     /* this is a file to read URLs from */
     char buffer[4096]; /* arbitrary max */
     bool end_of_file = false;
+    bool is_empty = true;
     while(!end_of_file && fgets(buffer, sizeof(buffer), o.url)) {
       char *eol = strchr(buffer, '\n');
       if(eol && (eol > buffer)) {
@@ -1618,6 +1619,7 @@ int main(int argc, const char **argv)
 
       if(eol > buffer) {
         /* if there is actual content left to deal with */
+        is_empty = false;
         struct iterinfo iinfo;
         memset(&iinfo, 0, sizeof(iinfo));
         *eol = 0; /* end of URL */
@@ -1625,6 +1627,8 @@ int main(int argc, const char **argv)
       }
     }
 
+    if(is_empty && !o.jsonout)
+      errorf(&o, ERROR_BADURL, "not enough input for a URL");
     if(!end_of_file && ferror(o.url))
       trurl_warnf(&o, "fgets: %s", strerror(errno));
     if(o.urlopen)

--- a/trurl.c
+++ b/trurl.c
@@ -1572,9 +1572,11 @@ int main(int argc, const char **argv)
   if(o.jsonout)
     putchar('[');
 
+  /*
   if(!o.url && !o.iter_list && !isatty(STDIN_FILENO)) {
     o.url = stdin;
   }
+  */
 
 
   if(o.url) {

--- a/trurl.c
+++ b/trurl.c
@@ -1572,7 +1572,7 @@ int main(int argc, const char **argv)
   if(o.jsonout)
     putchar('[');
 
-  if(!o.url && !o.url_list && !isatty(STDIN_FILENO)) {
+  if(!o.url && !o.url_list && !o.iter_list && !isatty(STDIN_FILENO)) {
     o.url = stdin;
   }
 

--- a/trurl.c
+++ b/trurl.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <curl/curl.h>
 #include <curl/mprintf.h>
 #include <stdint.h>
@@ -1570,6 +1571,11 @@ int main(int argc, const char **argv)
 
   if(o.jsonout)
     putchar('[');
+
+  if(!o.url && !o.iter_list && isatty(STDIN_FILENO)) {
+    o.url = stdin;
+  }
+
 
   if(o.url) {
     /* this is a file to read URLs from */

--- a/trurl.c
+++ b/trurl.c
@@ -1573,6 +1573,7 @@ int main(int argc, const char **argv)
     putchar('[');
 
   if(!o.url && !o.iter_list && !isatty(STDIN_FILENO)) {
+    printf("What is going on?? are we getting in here?\n");
     o.url = stdin;
   }
 

--- a/trurl.c
+++ b/trurl.c
@@ -1572,8 +1572,6 @@ int main(int argc, const char **argv)
   if(o.jsonout)
     putchar('[');
 
-  // if iter_list and url havent been set AND we're not running in 
-  // a TTY then use stdin to read URLs from.
   if(!o.url && !o.iter_list && !isatty(STDIN_FILENO)) {
     o.url = stdin;
   }

--- a/trurl.c
+++ b/trurl.c
@@ -1572,9 +1572,11 @@ int main(int argc, const char **argv)
   if(o.jsonout)
     putchar('[');
 
+  /*
   if(!o.url && !o.url_list && !o.set_list && !isatty(STDIN_FILENO)) {
     o.url = stdin;
   }
+  */
 
   if(o.url) {
     /* this is a file to read URLs from */

--- a/trurl.c
+++ b/trurl.c
@@ -1572,7 +1572,7 @@ int main(int argc, const char **argv)
   if(o.jsonout)
     putchar('[');
 
-  if(!o.url && !o.iter_list && isatty(STDIN_FILENO)) {
+  if(!o.url && !o.iter_list && !isatty(STDIN_FILENO)) {
     o.url = stdin;
   }
 

--- a/trurl.c
+++ b/trurl.c
@@ -1572,12 +1572,9 @@ int main(int argc, const char **argv)
   if(o.jsonout)
     putchar('[');
 
-  /*
   if(!o.url && !o.iter_list && !isatty(STDIN_FILENO)) {
     o.url = stdin;
   }
-  */
-
 
   if(o.url) {
     /* this is a file to read URLs from */

--- a/trurl.c
+++ b/trurl.c
@@ -1628,7 +1628,7 @@ int main(int argc, const char **argv)
     }
 
     if(is_empty && !o.jsonout)
-      errorf(&o, ERROR_BADURL, "not enough input for a URL");
+      errorf(&o, ERROR_URL, "not enough input for a URL");
     if(!end_of_file && ferror(o.url))
       trurl_warnf(&o, "fgets: %s", strerror(errno));
     if(o.urlopen)

--- a/trurl.c
+++ b/trurl.c
@@ -1572,8 +1572,7 @@ int main(int argc, const char **argv)
   if(o.jsonout)
     putchar('[');
 
-  if(!o.url && !o.iter_list && !isatty(STDIN_FILENO)) {
-    printf("What is going on?? are we getting in here?\n");
+  if(!o.url && !o.url_list && !isatty(STDIN_FILENO)) {
     o.url = stdin;
   }
 

--- a/trurl.c
+++ b/trurl.c
@@ -1572,6 +1572,8 @@ int main(int argc, const char **argv)
   if(o.jsonout)
     putchar('[');
 
+  // if iter_list and url havent been set AND we're not running in 
+  // a TTY then use stdin to read URLs from.
   if(!o.url && !o.iter_list && !isatty(STDIN_FILENO)) {
     o.url = stdin;
   }

--- a/trurl.c
+++ b/trurl.c
@@ -1572,7 +1572,7 @@ int main(int argc, const char **argv)
   if(o.jsonout)
     putchar('[');
 
-  if(!o.url && !o.url_list && !o.iter_list && !isatty(STDIN_FILENO)) {
+  if(!o.url && !o.url_list && !o.set_list && !isatty(STDIN_FILENO)) {
     o.url = stdin;
   }
 


### PR DESCRIPTION
This adds the ability to use pipes to read from stdin. Note that this keeps the `-f -` style as is, but can be removed if folks want that.
Example usage:
```
$ echo "www.google.com" | trurl 
http://www.google.com/
$ cat someurls.txt | trurl --get "{scheme}"
https
https
git
http
ftp
$ (trurl -s query="foo=bar") < someurls.txt
https://curl.se/?foobar
https://docs.python.org/?foobar
git://github.com/curl/curl.git?foobar
```

fixes #275 