### PR TITLE
use of free() instead of curl_free()

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -1282,7 +1282,7 @@ static void replace(struct option *o)
       if(strncmp(q, key.str, key.len))
         continue;
       free(qpairs[i].str);
-      curl_free(qpairsdec[i].str);
+      free(qpairsdec[i].str);
       /* this is a duplicate remove it. */
       if(replaced) {
         qpairs[i].len = 0;


### PR DESCRIPTION
This matters on some systems/setups. Most easily we can detect it by building with a libcurl built debug-enabled.