### PR TITLE
error when using an unrecognized URL component

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -822,6 +822,9 @@ static void get(struct option *o, CURLU *uh)
               break;
             }
           }
+          else
+            errorf(o, ERROR_GET, "\"%.*s\" is not a recognized URL component",
+                   (int)vlen, ptr);
         }
         ptr = end + 1; /* pass the end */
       }


### PR DESCRIPTION
To help user detect typos and error out hard rather than to just not do what the user expected.

Ref: #236