### PR TITLE
Trurl accept from stdin

### DIFF
--- a/test.py
+++ b/test.py
@@ -85,6 +85,7 @@ class TestCase:
         self.expected = testCase["expected"]
         self.commandOutput: CommandOutput = None
         self.testPassed: bool = False
+        self.stdin = testCase["input"].get("stdin", None)
 
     def runCommand(self, cmdfilter: Optional[str], runWithValgrind: bool):
         # Skip test if none of the arguments contain the keyword
@@ -103,7 +104,8 @@ class TestCase:
         output = run(
             cmd + args,
             stdout=PIPE, stderr=PIPE,
-            encoding="utf-8"
+            encoding="utf-8",
+            input=self.stdin
         )
 
         if isinstance(self.expected["stdout"], list):

--- a/tests.json
+++ b/tests.json
@@ -2444,5 +2444,44 @@
           "stderr": "",
           "returncode": 0
       }
+  },
+  {
+    "input": {
+        "stdin": "google.com",
+        "arguments": ["--get", "{path}"]
+    },
+    "expected": {
+        "returncode": 0,
+        "stderr": "",
+        "stdout": "/\n"
+    }
+  },
+  {
+    "input": {
+        "stdin": "http://example.org/?quest=best",
+        "arguments": [
+            "--replace",
+            "quest=%00",
+            "--json"
+        ]
+    },
+    "expected": {
+        "stdout": [{
+            "url": "http://example.org/?quest=%00",
+            "parts": {
+                "scheme": "http",
+                "host": "example.org",
+                "path": "/"
+            },
+            "params": [
+                {
+                    "key": "quest",
+                    "value": "\u0000"
+                }
+            ]
+        }],
+        "stderr": "",
+        "returncode": 0
+    }
   }
 ]

--- a/trurl.1
+++ b/trurl.1
@@ -84,7 +84,8 @@ scheme, this option is pretty much ignored unless one of \fI--get\fP,
 \fI--json\fP, and \fI--keep-port\fP is not also specified.
 .IP "-f, --url-file [file name]"
 Read URLs to work on from the given file. Use the file name "-" (a single
-minus) to tell trurl to read the URLs from stdin.
+minus) to tell trurl to read the URLs from stdin, or you may use pipes to feed
+urls to trurl.
 
 Each line needs to be a single valid URL. trurl will remove one carriage return
 character at the end of the line if present, trim off all the trailing space and

--- a/trurl.c
+++ b/trurl.c
@@ -1643,7 +1643,7 @@ int main(int argc, const char **argv)
     }
 
     if(is_empty && !o.jsonout)
-      errorf(&o, ERROR_URL, "not enough inputs for a URL");
+      errorf(&o, ERROR_URL, "not enough input for a URL");
     if(!end_of_file && ferror(o.url))
       trurl_warnf(&o, "fgets: %s", strerror(errno));
     if(o.urlopen)

--- a/trurl.c
+++ b/trurl.c
@@ -1643,7 +1643,7 @@ int main(int argc, const char **argv)
     }
 
     if(is_empty && !o.jsonout)
-      errorf(&o, ERROR_URL, "Not enough inputs for a URL");
+      errorf(&o, ERROR_URL, "not enough inputs for a URL");
     if(!end_of_file && ferror(o.url))
       trurl_warnf(&o, "fgets: %s", strerror(errno));
     if(o.urlopen)


### PR DESCRIPTION
this is a second pass at #277,  I'm not sure what I was doing last time but the tests seem to be working now. I left the original `-f -` behavior unchanged, but with this I think could we could take it out as its redundant - but also its a pretty common pattern so I have no strong feelings either way about keeping `-f -` in. 
Fixes #275 