### PR TITLE
Update github actions using deprecated workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
@@ -51,6 +51,6 @@ jobs:
         run: make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: install codespell
         run: |

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: 'list dependencies'
         run: cat urls.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: 'trurl-windows'
           retention-days: 5

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -25,7 +25,7 @@ jobs:
               LDFLAGS="-fsanitize=address,undefined,signed-integer-overflow -g"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install libcurl
         run: |
@@ -48,7 +48,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install cygwin
         uses: cygwin/cygwin-install-action@master
@@ -68,7 +68,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: make
         run: make

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -24,6 +24,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1


### PR DESCRIPTION
I noticed we had these deprecation warnings in our github actions, so I updated our workflows to fix these: 
<img width="1368" alt="Screenshot 2024-04-20 at 9 14 14 PM" src="https://github.com/curl/trurl/assets/8949007/b5bc1b4b-83aa-402a-8790-ba5db4fdfef3">

