### PR TITLE
Free allocated pointer on OOM error

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -1143,6 +1143,7 @@ static struct string *memdupdec(char *source, size_t len, bool json)
   curl_free(left);
   ret = malloc(sizeof(struct string));
   if(!ret) {
+    free(str);
     return NULL;
   }
   ret->str = str;


### PR DESCRIPTION
If the allocation of str fails, free the previous memory allocation in the error path.