### PR TITLE
trurl: only append the first iterate loop

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2512,5 +2512,37 @@
           "stderr": "",
           "returncode": 0
       }
+  },
+  {
+      "input": {
+          "arguments": [
+              "example.com",
+              "--append",
+              "query=add",
+              "--iterate",
+              "scheme=http ftp"
+          ]
+      },
+      "expected": {
+          "stdout": "http://example.com/?add\nftp://example.com/?add\n",
+          "stderr": "",
+          "returncode": 0
+      }
+  },
+  {
+      "input": {
+          "arguments": [
+              "example.com",
+              "--append",
+              "path=add",
+              "--iterate",
+              "scheme=http ftp"
+          ]
+      },
+      "expected": {
+          "stdout": "http://example.com/add\nftp://example.com/add\n",
+          "stderr": "",
+          "returncode": 0
+      }
   }
 ]


### PR DESCRIPTION
Since it works with the same URL object, doing repeated appends will keep appending every loop which is not intended.

Add test cases to verify.

Reported-by: Jacob Mealey
Fixes #299