### PR TITLE
return error when failing to get a URL component

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2544,5 +2544,33 @@
           "stderr": "",
           "returncode": 0
       }
+  },
+  {
+      "input": {
+          "arguments": [
+              "example.com?hello=%00",
+              "-g",
+              "{query}"
+          ]
+      },
+      "expected": {
+          "stdout": "",
+          "stderr": "trurl error: URL decode error, most likely because of rubbish in the input (query)\n\ntrurl error: Try trurl -h for help\n",
+          "returncode": 10
+      }
+  },
+  {
+      "input": {
+          "arguments": [
+              "example.com/hello%00",
+              "-g",
+              "{path}"
+          ]
+      },
+      "expected": {
+          "stdout": "",
+          "stderr": "trurl error: URL decode error, most likely because of rubbish in the input (path)\n\ntrurl error: Try trurl -h for help\n",
+          "returncode": 10
+      }
   }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -844,8 +844,8 @@ static void get(struct option *o, CURLU *uh)
               /* silently ignore */
               break;
             default:
-              trurl_warnf(o, "%s (%s)\n", curl_url_strerror(rc), v->name);
-              break;
+              errorf(o, ERROR_GET,
+                     "%s (%s)\n", curl_url_strerror(rc), v->name);
             }
           }
           else


### PR DESCRIPTION
Most typically when %00 or something crazy is used in the component and it is extracted URL decoded. Makes trurl return ERROR_GET (10) now.

Added two tests to verify.

Reported-by: yahesh on github
Fixes #305