### PR TITLE
trurl: add "strict:" as prefix to a get component

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2544,5 +2544,33 @@
           "stderr": "",
           "returncode": 0
       }
+  },
+  {
+      "input": {
+          "arguments": [
+              "https://curl.se?name=mr%00smith",
+              "--get",
+              "{query}"
+          ]
+      },
+      "expected": {
+          "stderr": "trurl note: URL decode error, most likely because of rubbish in the input (query)\n",
+          "returncode": 0,
+          "stdout": "\n"
+      }
+  },
+  {
+      "input": {
+          "arguments": [
+              "https://curl.se?name=mr%00smith",
+              "--get",
+              "{strict:query}"
+          ]
+      },
+      "expected": {
+          "stderr": "trurl error: problems URL decoding query\ntrurl error: Try trurl -h for help\n",
+          "returncode": 10,
+          "stdout": ""
+      }
   }
 ]

--- a/trurl.1
+++ b/trurl.1
@@ -109,10 +109,17 @@ user, password, options, host, port, path, query, fragment and zoneid.
 not have a value.
 
 Components are shown URL decoded by default. If you instead write the
-component prefixed with a colon like "{:path}", it gets output URL encoded.
+component prefixed with "url:" like "{url:path}", it gets output URL encoded.
+As a shortcut, "url:" also works written as a single colon: "{:path}".
 
-You may also prefix components with \fBdefault:\fP and/or \fBpuny:\fP or \fBidn:\fP,
-in any order.
+URL decoding a component may cause problems to display it. Such problems make
+a warning get displayed unless \fB--quiet\fP is used. URL decode problems can
+optionally be turned into errors by prefixing the comopnent name with
+"strict:", as in "{strict:path}". In this stricter mode, a URL decode problem
+makes trurl stop what it is doing and return with exit code 10.
+
+You may also prefix components with \fBdefault:\fP and/or \fBpuny:\fP or
+\fBidn:\fP, in any order.
 
 If \fBdefault:\fP is specified, like "{default:url}" or
 "{default:port}", and the port is not explicitly specified in the URL,


### PR DESCRIPTION
The strict prefix makes trurl immediately exit with an error code if such a get can't be done due to URL decoding problems. By default, such a problem will only make trurl skip that part and silently continue.

Use it like this: --get "{strict:query}"

I also made "url:" a valid prefix, and now we consider the single colon prefix to be a shortcut for url:. The concept of prefixes scale better when we use real words instead of single characters.

Ref: #305