### PR TITLE
casecompare: a strncasemp replacement

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -46,8 +46,6 @@ typedef enum {
 #include "version.h"
 
 #ifdef _MSC_VER
-#define strncasecmp _strnicmp
-#define strcasecmp _stricmp
 #define strdup _strdup
 #endif
 
@@ -150,6 +148,52 @@ static char *curl_url_strerror(CURLUcode error)
   return buffer;
 }
 #endif
+
+/* Mapping table to go from lowercase to uppercase for plain ASCII.*/
+static const unsigned char touppermap[256] = {
+0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78,
+79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 65,
+66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
+85, 86, 87, 88, 89, 90, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133,
+134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
+150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165,
+166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181,
+182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197,
+198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213,
+214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229,
+230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245,
+246, 247, 248, 249, 250, 251, 252, 253, 254, 255
+};
+
+/* Portable, ASCII-consistent toupper. Do not use toupper() because its
+   behavior is altered by the current locale. */
+#define raw_toupper(in) touppermap[(unsigned int)in]
+
+/*
+ * casecompare() does ASCII based case insensitive checks, as a strncasecmp
+ * replacement.
+ */
+
+static int casecompare(const char *first, const char *second, size_t max)
+{
+  while(*first && *second && max) {
+    int diff = raw_toupper(*first) - raw_toupper(*second);
+    if(diff)
+      /* get out of the loop as soon as they don't match */
+      return diff;
+    max--;
+    first++;
+    second++;
+  }
+  if(!max)
+    return 0; /* identical to this point */
+
+  return raw_toupper(*first) - raw_toupper(*second);
+}
+#define strncasecmp(x,y,z) casecompare(x,y,z)
 
 static void message_low(const char *prefix, const char *suffix,
                         const char *fmt, va_list ap)


### PR DESCRIPTION
Avoid using strncasecmp() because it relies on and uses the current locale which makes it work differently depending on where it runs. Including locales where 'i' and 'I' are not matching case insensitively.