### PR TITLE
Handle Errors returns from geturlpart() in json function

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2088,7 +2088,8 @@
         "input" : {
             "arguments": [
                 "http://example.com/?q=mr%00smith",
-                "--json"
+                "--json",
+                "--urlencode"
             ]
         },
         "expected": {
@@ -2100,7 +2101,8 @@
                     "parts": {
                         "scheme": "http",
                         "host": "example.com",
-                        "path": "/"
+                        "path": "/",
+                        "query": "q=mr%00smith"
                     },
                     "params": [
                         {
@@ -2116,7 +2118,8 @@
         "input" : {
             "arguments": [
                 "http://example.com/?q=mr%00sm%00ith",
-                "--json"
+                "--json",
+                "--urlencode"
             ]
         },
         "expected": {
@@ -2128,7 +2131,8 @@
                     "parts": {
                         "scheme": "http",
                         "host": "example.com",
-                        "path": "/"
+                        "path": "/",
+                        "query": "q=mr%00sm%00ith"
                     },
                     "params": [
                         {
@@ -2144,7 +2148,8 @@
         "input" : {
             "arguments": [
                 "http://example.com/?q=mr%00%00%00smith",
-                "--json"
+                "--json",
+                "--urlencode"
             ]
         },
         "expected": {
@@ -2156,7 +2161,8 @@
                     "parts": {
                         "scheme": "http",
                         "host": "example.com",
-                        "path": "/"
+                        "path": "/",
+                        "query": "q=mr%00%00%00smith"
                     },
                     "params": [
                         {
@@ -2354,7 +2360,8 @@
                 "example.org/?quest=best",
                 "--replace",
                 "quest=%00",
-                "--json"
+                "--json",
+                "--urlencode"
             ]
         },
         "expected": {
@@ -2363,7 +2370,8 @@
 				"parts": {
 					"scheme": "http",
 					"host": "example.org",
-					"path": "/"
+					"path": "/",
+                    "query": "quest=%00"
 				},
 				"params": [
 					{
@@ -2419,7 +2427,8 @@
       "input": {
           "arguments": [
               "--json",
-              "0?0%000000000000000000000000000000000"
+              "0?0%000000000000000000000000000000000",
+              "--urlencode"
           ]
       },
       "expected": {
@@ -2431,7 +2440,8 @@
                   "parts": {
                       "scheme": "http",
                       "host": "0.0.0.0",
-                      "path": "/"
+                      "path": "/",
+                      "query": "0%000000000000000000000000000000000"
                   },
                   "params": [
                       {
@@ -2447,7 +2457,8 @@
       "input": {
           "arguments": [
               "--json",
-              "0?0%000000000000000000000000000000000=000%0000000000"
+              "0?0%000000000000000000000000000000000=000%0000000000",
+              "--urlencode"
           ]
       },
       "expected": {
@@ -2459,7 +2470,8 @@
                   "parts": {
                       "scheme": "http",
                       "host": "0.0.0.0",
-                      "path": "/"
+                      "path": "/",
+                      "query": "0%000000000000000000000000000000000=000%0000000000"
                   },
                   "params": [
                       {
@@ -2601,5 +2613,26 @@
           "stderr": "",
           "returncode": 0
       }
+  },
+  {
+    "input": {
+        "arguments": [
+            "http://example.org/%18",
+            "--json"
+        ]
+    },
+    "expected": {
+        "stdout":[
+            {
+                "url": "http://example.org/%18",
+                "parts": {
+                  "scheme": "http",
+                  "host": "example.org"
+                }
+              }
+        ],
+        "stderr": "trurl note: URL decode error, most likely because of rubbish in the input (path)\n",
+        "returncode": 0
+    }
   }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -1101,7 +1101,7 @@ static void json(struct option *o, CURLU *uh)
   jsonString(stdout, url, strlen(url), false);
   curl_free(url);
   fputs(",\n    \"parts\": {\n", stdout);
-  // special error handling required to not print params array.
+  /* special error handling required to not print params array. */
   bool params_errors = false;
   for(i = 0; variables[i].name; i++) {
     char *part;

--- a/trurl.c
+++ b/trurl.c
@@ -764,6 +764,29 @@ static CURLUcode geturlpart(struct option *o, int modifiers, CURLU *uh,
     return rc;
 }
 
+static bool is_valid_trurl_error(CURLUcode rc)
+{
+  switch(rc) {
+    case CURLUE_OK:
+    case CURLUE_NO_SCHEME:
+    case CURLUE_NO_USER:
+    case CURLUE_NO_PASSWORD:
+    case CURLUE_NO_OPTIONS:
+    case CURLUE_NO_HOST:
+    case CURLUE_NO_PORT:
+    case CURLUE_NO_QUERY:
+    case CURLUE_NO_FRAGMENT:
+#ifdef SUPPORTS_ZONEID
+    case CURLUE_NO_ZONEID:
+#endif
+    /* silently ignore */
+      return false;
+    default:
+      return true;
+    }
+  return true;
+}
+
 static void showurl(FILE *stream, struct option *o, int modifiers,
                     CURLU *uh)
 {
@@ -883,29 +906,15 @@ static void get(struct option *o, CURLU *uh)
           if(v) {
             char *nurl;
             CURLUcode rc = geturlpart(o, mods, uh, v->part, &nurl);
-            switch(rc) {
-            case CURLUE_OK:
+            if(rc == CURLUE_OK) {
               fputs(nurl, stream);
               curl_free(nurl);
-            case CURLUE_NO_SCHEME:
-            case CURLUE_NO_USER:
-            case CURLUE_NO_PASSWORD:
-            case CURLUE_NO_OPTIONS:
-            case CURLUE_NO_HOST:
-            case CURLUE_NO_PORT:
-            case CURLUE_NO_QUERY:
-            case CURLUE_NO_FRAGMENT:
-#ifdef SUPPORTS_ZONEID
-            case CURLUE_NO_ZONEID:
-#endif
-              /* silently ignore */
-              break;
-            default:
+            }
+            else if(is_valid_trurl_error(rc)) {
               if((rc == CURLUE_URLDECODE) && strict)
                 errorf(o, ERROR_GET, "problems URL decoding %s", v->name);
               else
                 trurl_warnf(o, "%s (%s)", curl_url_strerror(rc), v->name);
-              break;
             }
           }
           else
@@ -1092,6 +1101,8 @@ static void json(struct option *o, CURLU *uh)
   jsonString(stdout, url, strlen(url), false);
   curl_free(url);
   fputs(",\n    \"parts\": {\n", stdout);
+  // special error handling required to not print params array.
+  bool params_errors = false;
   for(i = 0; variables[i].name; i++) {
     char *part;
     rc = geturlpart(o, 0, uh, variables[i].part, &part);
@@ -1103,10 +1114,14 @@ static void json(struct option *o, CURLU *uh)
       jsonString(stdout, part, strlen(part), false);
       curl_free(part);
     }
+    else if(is_valid_trurl_error(rc)) {
+        trurl_warnf(o, "%s (%s)", curl_url_strerror(rc), variables[i].name);
+        params_errors = true;
+    }
   }
   fputs("\n    }", stdout);
   first = true;
-  if(nqpairs) {
+  if(nqpairs && !params_errors) {
     int j;
     fputs(",\n    \"params\": [\n", stdout);
     for(j = 0 ; j < nqpairs; j++) {
@@ -1440,6 +1455,7 @@ static void replace(struct option *o)
     query_is_modified = true;
   }
 }
+
 static CURLUcode seturl(struct option *o, CURLU *uh, const char *url)
 {
   return curl_url_set(uh, CURLUPART_URL, url,


### PR DESCRIPTION
This PR adds a trurl_warnf call in json() to have it handle  bad return codes from geturlpart() where previously it was silently failing. this aligns the behavior of `--get` and `--json`. This silent error also meant trurl would attempt to print all params even if the call to geturlpart fails which is now fixed.

this pr sort of fixes #262. like I said above it aligns `--get` and `--json` so if there are control sequences in the input they will both return the same error unless you call  it with `--urlencode`

