### PR TITLE
add trurl / libcurl compatibilty to readme. link to URL quirks

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,19 @@ if someone wanted to.
 
 trurl builds with libcurl older than 7.81.0 but will then not work as
 good. For all the documented goodness, use a more modern libcurl.
+
+### trurl / libcurl Compatibility
+
+| trurl Feature |  Minimum libcurl Version |
+|---------------|----------------------|
+| imap-options  |   7.30.0             |
+| normalize-ipv |   7.77.0             | 
+| white-space   |   7.78.0             |
+| url-strerror  |   7.80.0             |
+| zone-id       |   7.81.0             |
+| punycode      |   7.88.0             |
+| punycode2idn  |   8.3.0              |
+
+For more details on how trurl will behave if these features are missing see [URL Quirks](https://github.com/curl/trurl/blob/master/URL-QUIRKS.md).
+To see the features your version of trurl supports as well as the version of libcurl it is built with, run the following command:  `trurl --version`
+

--- a/README.md
+++ b/README.md
@@ -165,15 +165,16 @@ good. For all the documented goodness, use a more modern libcurl.
 
 ### trurl / libcurl Compatibility
 
-| trurl Feature |  Minimum libcurl Version |
-|---------------|----------------------|
-| imap-options  |   7.30.0             |
-| normalize-ipv |   7.77.0             | 
-| white-space   |   7.78.0             |
-| url-strerror  |   7.80.0             |
-| zone-id       |   7.81.0             |
-| punycode      |   7.88.0             |
-| punycode2idn  |   8.3.0              |
+| trurl Feature   |  Minimum libcurl Version |
+|-----------------|--------------------------|
+| imap-options    |   7.30.0                 |
+| normalize-ipv   |   7.77.0                 | 
+| white-space     |   7.78.0                 |
+| url-strerror    |   7.80.0                 |
+| zone-id         |   7.81.0                 |
+| punycode        |   7.88.0                 |
+| punycode2idn    |   8.3.0                  |
+| no-guess-scheme |   8.9.0                  |
 
 For more details on how trurl will behave if these features are missing see [URL Quirks](https://github.com/curl/trurl/blob/master/URL-QUIRKS.md).
 To see the features your version of trurl supports as well as the version of libcurl it is built with, run the following command:  `trurl --version`

--- a/URL-QUIRKS.md
+++ b/URL-QUIRKS.md
@@ -1,6 +1,6 @@
 # URL Quirks
 
-This is a collection peculiarities to may find in trurl due to bugs or
+This is a collection peculiarities you may find in trurl due to bugs or
 changes/improvements in libcurl's URL handling.
 
 ## The URL API

--- a/URL-QUIRKS.md
+++ b/URL-QUIRKS.md
@@ -1,6 +1,6 @@
 # URL Quirks
 
-This is a collection peculiarities you may find in trurl due to bugs or
+This is a collection of peculiarities you may find in trurl due to bugs or
 changes/improvements in libcurl's URL handling.
 
 ## The URL API


### PR DESCRIPTION
Add a quick easy to read to table to the readme mapping trurl features to libcurl versions required. 