### PR TITLE
trurl: make --replace URL encode the provided data argument

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2366,17 +2366,17 @@
         },
         "expected": {
 			"stdout": [{
-				"url": "http://example.org/?quest=%00",
+				"url": "http://example.org/?quest=%2500",
 				"parts": {
 					"scheme": "http",
 					"host": "example.org",
 					"path": "/",
-                    "query": "quest=%00"
+                    "query": "quest=%2500"
 				},
 				"params": [
 					{
 						"key": "quest",
-						"value": "\u0000"
+						"value": "%00"
 					}
 				]
 			}],

--- a/trurl.1
+++ b/trurl.1
@@ -211,6 +211,9 @@ Replaces a URL query.
 data can either take the form of a single value, or as a key/value pair in the
 shape \fIfoo=bar\fP. If replace is called on an item that isn't in the list of
 queries trurl ignores that item.
+
+trurl URL encodes both sides of the '=' character in the given input data
+argument.
 .IP "--force-replace [data]"
 Works the same as \fI--replace\fP, but trurl appends a missing query string if
 it is not in the query list already.


### PR DESCRIPTION
Makes it work like --append query= already does.

- update man page
- update test cases

Fixes #321