### PR TITLE
trurl: "normalize" query pairs

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -981,7 +981,7 @@
             ]
         },
         "expected": {
-            "stdout": "tra%20cker\n",
+            "stdout": "tra+cker\n",
             "stderr": "",
             "returncode": 0
         }
@@ -1132,7 +1132,7 @@
             ]
         },
         "expected": {
-            "stdout": "https://example.com/?address%20=home:here=now:thisthen:utm=tra%20cker\n",
+            "stdout": "https://example.com/?address+=home:here=now:thisthen:utm=tra+cker\n",
             "stderr": "",
             "returncode": 0
         }
@@ -1344,7 +1344,7 @@
             "returncode": 0,
             "stdout": [
                 {
-                    "url": "https://example.com/?utm=tra%20cker&address%20=home&here=now&thisthen",
+                    "url": "https://example.com/?utm=tra+cker&address+=home&here=now&thisthen",
                     "parts": {
                         "scheme": "https",
                         "host": "example.com",


### PR DESCRIPTION
To properly handle https://example.com/?%611&a2&a3 --trim query=a*, trurl now "normalizes" the query pairs by an extra round of URL decode + encode.

If a query pair gets normalized, consider it modified which in turn triggers a URL update. Thus

  trurl 'https://example.com/?%611&a2&a3'

outputs

  https://example.com/?a1&a2&a3

The query part URL encodes spaces to pluses (and vice versa). Note that %20 in the query in the input URL will be normalized to a +.

Updated several tests accordingly.

Reported-by: Emanuele Torre
Fixes #326