### PR TITLE
trurl: optimize the path append loop

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2560,6 +2560,22 @@
   {
       "input": {
           "arguments": [
+              "example.com",
+              "--append",
+              "path=add",
+              "--append",
+              "path=two"
+          ]
+      },
+      "expected": {
+          "stdout": "http://example.com/add/two\n",
+          "stderr": "",
+          "returncode": 0
+      }
+  },
+  {
+      "input": {
+          "arguments": [
               "https://curl.se?name=mr%00smith",
               "--get",
               "{query}"


### PR DESCRIPTION
Extract the path once, do all the appends then set the final version once in the end. Instead of doing it every loop.