### PR TITLE
trurl: rename --force-replace to --replace-append

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2410,7 +2410,21 @@
             "stderr": "trurl note: key 'key' not in url, appending to query\n",
             "returncode": 0
         }
-  },
+    },
+    {
+    "input": {
+            "arguments": [
+                "http://test.org/?that=thing",
+                "--replace-append",
+                "key=foo"
+            ]
+        },
+        "expected": {
+            "stdout": "http://test.org/?that=thing&key=foo\n",
+            "stderr": "trurl note: key 'key' not in url, appending to query\n",
+            "returncode": 0
+        }
+    },
   {
       "input": {
           "arguments": [

--- a/trurl.1
+++ b/trurl.1
@@ -214,7 +214,7 @@ queries trurl ignores that item.
 
 trurl URL encodes both sides of the '=' character in the given input data
 argument.
-.IP "--force-replace [data]"
+.IP "--replace--append [data]"
 Works the same as \fI--replace\fP, but trurl appends a missing query string if
 it is not in the query list already.
 .IP "-s, --set [component][:]=[data]"
@@ -466,7 +466,7 @@ A problem with --get
 .IP 11
 A problem with --iterate
 .IP 12
-A problem with --replace or --force-replace
+A problem with --replace or --replace-append
 .SH WWW
 https://curl.se/trurl
 .SH "SEE ALSO"

--- a/trurl.c
+++ b/trurl.c
@@ -227,6 +227,7 @@ static void help(void)
     "Usage: " PROGNAME " [options] [URL]\n"
     "  -a, --append [component]=[data]  - append data to component\n"
     "      --accept-space               - give in to this URL abuse\n"
+    "      --as-idn                     - encode hostnames in idn\n"
     "      --curl                       - only schemes supported by libcurl\n"
     "      --default-port               - add known default ports\n"
     "  -f, --url-file [file/-]          - read URLs from file or stdin\n"
@@ -237,11 +238,11 @@ static void help(void)
     "      --keep-port                  - keep known default ports\n"
     "      --no-guess-scheme            - require scheme in URLs\n"
     "      --punycode                   - encode hostnames in punycode\n"
-    "      --as-idn                     - encode hostnames in idn\n"
     "      --query-separator [letter]   - if something else than '&'\n"
+    "      --quiet                      - Suppress (some) notes and comments\n"
     "      --redirect [URL]             - redirect to this\n"
     "      --replace [data]             - replaces a query [data]\n"
-    "      --force-replace [data]       - appends a new query if not found\n"
+    "      --replace-append [data]      - appends a new query if not found\n"
     "  -s, --set [component]=[data]     - set component content\n"
     "      --sort-query                 - alpha-sort the query pairs\n"
     "      --trim [component]=[what]    - trim component\n"
@@ -249,7 +250,6 @@ static void help(void)
     "      --urlencode                  - URL encode components by default\n"
     "  -v, --version                    - show version\n"
     "      --verify                     - return error on (first) bad URL\n"
-    "      --quiet                      - Suppress (some) notes and comments\n"
     " URL COMPONENTS:\n"
     "  ", stdout);
   fputs("url, ", stdout);
@@ -699,7 +699,8 @@ static int getarg(struct option *o,
     replaceadd(o, arg);
     *usedarg = gap;
   }
-  else if(!strcmp("--force-replace", flag)) {
+  else if(!strcmp("--replace-append", flag) ||
+          !strcmp("--force-replace", flag)) { /* the initial name */
     replaceadd(o, arg);
     o->force_replace = true;
     *usedarg = gap;


### PR DESCRIPTION
To make the name better match its functionality. Keep support for the old name (but don't advertise it).

Alphasort the -h output

Add test to verify that both names work.