### PR TITLE
trurl: allow "control bytes" in JSON output

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2644,27 +2644,51 @@
           "returncode": 0
       }
   },
-  {
-    "input": {
-        "arguments": [
-            "http://example.org/%18",
-            "--json"
-        ]
-    },
-    "expected": {
-        "stdout":[
-            {
-                "url": "http://example.org/%18",
-                "parts": {
-                  "scheme": "http",
-                  "host": "example.org"
+    {
+        "input": {
+            "arguments": [
+                "http://example.org/%18",
+                "--json"
+            ]
+        },
+        "expected": {
+            "stdout":[
+                {
+                    "url": "http://example.org/%18",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "example.org",
+                        "path": "/\u0018"
+                    }
                 }
-              }
-        ],
-        "stderr": "trurl note: URL decode error, most likely because of rubbish in the input (path)\n",
-        "returncode": 0
-    }
-  },
+            ],
+            "stderr": "",
+            "returncode": 0
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "http://example.org/%18",
+                "--json",
+                "--urlencode"
+            ]
+        },
+        "expected": {
+            "stdout":[
+                {
+                    "url": "http://example.org/%18",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "example.org",
+                        "path": "/%18"
+                    }
+                }
+            ],
+            "stderr": "",
+            "returncode": 0
+        }
+    },
   {
       "input": {
           "arguments": [


### PR DESCRIPTION
For example when doing

    trurl 'http://example.org/%18' --json

Adapted and extended test cases to verify.

Fixes #262
Reported-by: Emanuele Torre