### PR TITLE
mkrelease: generate a release tarball

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -4,7 +4,7 @@
 
  - Makefile: fix LDFLAGS order; and don't force -Werror
  - README: add the logo
- - README: add trurl / libcurl compatibilty to readme. link to URL quirks
+ - README: add trurl / libcurl compatibility to readme. link to URL quirks
  - singleurl: fix query_is_modified
  - trurl.md: provide the manpage in markdown
  - trurl: "normalize" query pairs

--- a/mkrelease
+++ b/mkrelease
@@ -1,3 +1,4 @@
+#!/bin/sh
 ##########################################################################
 #                                  _   _ ____  _
 #  Project                     ___| | | |  _ \| |
@@ -34,5 +35,51 @@ if [ -z "$version" ]; then
   exit
 fi
 
+rel="trurl-$version"
+
+mkdir $rel
+
+# update title in markdown manpage
 sed -ie "s/^Title: trurl \([0-9.]*\)/Title: trurl $version/" trurl.md
+
+# update version number in header file
 sed -ie "s/\"[\.0-9]*\"/\"$version\"/" version.h
+
+# render the manpage into nroff
+./curl/scripts/cd2nroff trurl.md > $rel/trurl.1
+
+# create a release directory tree
+cp -p --parents $(git ls-files | grep -vE '^(.github/|.reuse/|.gitignore|LICENSES/)') $rel
+
+# create tarball from the tree
+targz="$rel.tar.gz"
+tar cfz "$targz" "$rel"
+
+timestamp=${SOURCE_DATE_EPOCH:-$(date +"%s")}
+filestamp=$(date -d "@$timestamp" +"%Y%m%d%H%M.%S")
+
+retar() {
+  tempdir=$1
+  rm -rf "$tempdir"
+  mkdir "$tempdir"
+  cd "$tempdir"
+  gzip -dc "../$targz" | tar -xf -
+  find trurl-* -depth -exec touch -c -t "$filestamp" '{}' +
+  tar --create --format=ustar --owner=0 --group=0 --numeric-owner --sort=name trurl-* | gzip --best --no-name > out.tar.gz
+  mv out.tar.gz ../
+  cd ..
+  rm -rf "$tempdir"
+}
+
+# make it reproducible
+retar ".tarbuild"
+mv out.tar.gz "$targz"
+
+# remove the temporary directory
+rm -rf $rel
+
+# Set deterministic timestamp
+touch -c -t "$filestamp" "$targz"
+
+echo "Now sign the release:"
+echo "gpg -b -a '$targz'"


### PR DESCRIPTION
The tarball contains a trurl.1, the nroff/manpage version of trurl.md, generated with cd2nroff from curl/scripts