### PR TITLE
trurl: Split install to install-bin and install-man

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CFLAGS += -Wconversion -Wmissing-prototypes -Wwrite-strings -Wsign-compare -Wno-
 ifndef NDEBUG
 CFLAGS += -Werror -g
 endif
-MANUAL = trurl.1
+MANUAL = trurl.md
 
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
@@ -48,9 +48,15 @@ $(TARGET): $(OBJS)
 trurl.o: trurl.c version.h
 
 .PHONY: install
-install:
+install: install-bin install-man
+
+.PHONY: install-bin
+install-bin:
 	$(INSTALL) -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+
+.PHONY: install-man
+install-man:
 	$(INSTALL) -d $(DESTDIR)$(MANDIR)
 	$(INSTALL) -m 0644 $(MANUAL) $(DESTDIR)$(MANDIR)
 


### PR DESCRIPTION
Split install target to install-bin and install-man, to provide for separate program and manual page installation for the cases where packaging needs to build trurl.1 from trurl.md using pandoc, for example.

In FreeBSD ports, we provide pre-rendered trurl.1 version for now, built from trurl.md, to avoid build-time dependency on hs-pandoc.

Also, MANUAL should read "trurl.md", even if markdown files are likely not to belong into MANDIR.