### PR TITLE
manpage: fix 0.15 mistakes

### DIFF
--- a/mkrelease
+++ b/mkrelease
@@ -40,7 +40,7 @@ rel="trurl-$version"
 mkdir $rel
 
 # update title in markdown manpage
-sed -ie "s/^Title: trurl \([0-9.]*\)/Title: trurl $version/" trurl.md
+sed -ie "s/^Source: trurl \([0-9.]*\)/Source: trurl $version/" trurl.md
 
 # update version number in header file
 sed -ie "s/\"[\.0-9]*\"/\"$version\"/" version.h

--- a/trurl.md
+++ b/trurl.md
@@ -1,9 +1,9 @@
 ---
 c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
 SPDX-License-Identifier: curl
-Title: trurl 0.15
+Title: trurl
 Section: 1
-Source: trurl
+Source: trurl 0.15
 See-also:
   - curl (1)
   - wcurl (1)
@@ -289,7 +289,7 @@ trailing asterisk (`*`)) which makes trurl remove the tuples from the query
 string that match the instruction.
 
 To match a literal trailing asterisk instead of using a wildcard, escape it with
-a backslash in front of it. Like `\*`.
+a backslash in front of it. Like `\\*`.
 
 ## --url [URL]
 


### PR DESCRIPTION
- put the version number on the right place
- escape the backslash in markdown correctly

Fixes #347 