### PR TITLE
Makefile: check for trurl.1 before installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,9 @@ install:
 	$(INSTALL) -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 	$(INSTALL) -d $(DESTDIR)$(MANDIR)
-	$(INSTALL) -m 0644 $(MANUAL) $(DESTDIR)$(MANDIR)
+	(if test -f $(MANUAL); then \
+	$(INSTALL) -m 0644 $(MANUAL) $(DESTDIR)$(MANDIR); \
+	fi)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Simply skips the operation if there is no .1 file around. The manpage version is shipped in tarballs but is not present in git.