### PR TITLE
trurl: make sure URL encoded %-hex is done lowercase

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2956,5 +2956,29 @@
             "stderr": "",
             "returncode": 0
         }
+    },
+    {
+        "input": {
+            "arguments": [
+                "http://example.com/?a=%5D"
+            ]
+        },
+        "expected": {
+            "stdout": "http://example.com/?a=%5d\n",
+            "stderr": "",
+            "returncode": 0
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "http://example.com/?a=%5D&b=%5D"
+            ]
+        },
+        "expected": {
+            "stdout": "http://example.com/?a=%5d&b=%5d\n",
+            "stderr": "",
+            "returncode": 0
+        }
     }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -1340,7 +1340,7 @@ static char *encodequery(char *str, size_t len)
       *dupe++ = in;
     else {
       /* encode it */
-      const char hex[] = "0123456789ABCDEF";
+      const char hex[] = "0123456789abcdef";
       dupe[0]='%';
       dupe[1] = hex[in>>4];
       dupe[2] = hex[in & 0xf];


### PR DESCRIPTION
Match how libcurl does it. Add two tests to verify.

Fixes #357
Reported-by: Peter Schilling