### PR TITLE
trurl: silence --replace-append when appending

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -2495,7 +2495,7 @@
         },
         "expected": {
             "stdout": "http://test.org/?that=thing&key=foo\n",
-            "stderr": "trurl note: key 'key' not in url, appending to query\n",
+            "stderr": "",
             "returncode": 0
         }
     },
@@ -2509,7 +2509,7 @@
         },
         "expected": {
             "stdout": "http://test.org/?that=thing&key=foo\n",
-            "stderr": "trurl note: key 'key' not in url, appending to query\n",
+            "stderr": "",
             "returncode": 0
         }
     },

--- a/trurl.c
+++ b/trurl.c
@@ -1661,9 +1661,6 @@ static bool replace(struct option *o)
     }
 
     if(!replaced && o->force_replace) {
-      trurl_warnf(o, "key '%.*s' not in url, appending to query",
-                  (int) (key.len),
-                  key.str);
       addqpair(key.str, strlen(key.str), o->jsonout);
       query_is_modified = true;
     }


### PR DESCRIPTION
Previously trurl would output a "note" when it did not replace a query name and instead appends it, but since that is just part of its documented behavior that output seems superfluous and rather annoying.

Update two tests accordingly.