### PR TITLE
trurl: introduce --qtrim for trimming queries (only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ trurl "https://fake.host/hello#frag" --set user=::moo:: --json
 **Remove tracking tuples from query:**
 
 ```text
-$ trurl "https://curl.se?search=hey&utm_source=tracker" --trim query="utm_*"
+$ trurl "https://curl.se?search=hey&utm_source=tracker" --qtrim "utm_*"
 https://curl.se/?search=hey
 ```
 
@@ -114,7 +114,7 @@ https://example.com?a=c&b=a&c=b
 **Work with a query that uses a semicolon separator:**
 
 ```text
-$ trurl "https://curl.se?search=fool;page=5" --trim query="search" --query-separator ";"
+$ trurl "https://curl.se?search=fool;page=5" --qtrim "search" --query-separator ";"
 https://curl.se?page=5
 ```
 

--- a/tests.json
+++ b/tests.json
@@ -830,6 +830,20 @@
     {
         "input": {
             "arguments": [
+                "https://example.com?search=hello&utm_source=tracker",
+                "--qtrim",
+                "utm_*"
+            ]
+        },
+        "expected": {
+            "stdout": "https://example.com/?search=hello\n",
+            "stderr": "",
+            "returncode": 0
+        }
+    },
+    {
+        "input": {
+            "arguments": [
                 "https://example.com?search=hello&utm_source=tracker&more=data",
                 "--trim",
                 "query=utm_*"
@@ -844,9 +858,23 @@
     {
         "input": {
             "arguments": [
+                "https://example.com?search=hello&utm_source=tracker&more=data",
+                "--qtrim",
+                "utm_*"
+            ]
+        },
+        "expected": {
+            "stdout": "https://example.com/?search=hello&more=data\n",
+            "stderr": "",
+            "returncode": 0
+        }
+    },
+    {
+        "input": {
+            "arguments": [
                 "https://example.com?search=hello&more=data",
-                "--trim",
-                "query=utm_*"
+                "--qtrim",
+                "utm_*"
             ]
         },
         "expected": {
@@ -873,8 +901,8 @@
         "input": {
             "arguments": [
                 "https://example.com?search=hello&utm_source=tracker&more=data",
-                "--trim",
-                "query=utm_source"
+                "--qtrim",
+                "utm_source"
             ]
         },
         "expected": {
@@ -887,12 +915,12 @@
         "input": {
             "arguments": [
                 "https://example.com?search=hello&utm_source=tracker&more=data",
-                "--trim",
-                "query=utm_source",
-                "--trim",
-                "query=more",
-                "--trim",
-                "query=search"
+                "--qtrim",
+                "utm_source",
+                "--qtrim",
+                "more",
+                "--qtrim",
+                "search"
             ]
         },
         "expected": {
@@ -951,8 +979,8 @@
         "input": {
             "arguments": [
                 "https://example.com?moo&search=hello",
-                "--trim",
-                "query=search"
+                "--qtrim",
+                "search"
             ]
         },
         "expected": {
@@ -965,8 +993,8 @@
         "input": {
             "arguments": [
                 "https://example.com?search=hello&moo",
-                "--trim",
-                "query=search"
+                "--qtrim",
+                "search"
             ]
         },
         "expected": {
@@ -979,8 +1007,8 @@
         "input": {
             "arguments": [
                 "https://example.com?search=hello",
-                "--trim",
-                "query=search",
+                "--qtrim",
+                "search",
                 "--append",
                 "query=moo"
             ]
@@ -2157,8 +2185,8 @@
     {
         "input": {
             "arguments": [
-                "--trim",
-                "query=a",
+                "--qtrim",
+                "a",
                 "-a",
                 "query=a=ciao",
                 "-a",
@@ -2267,8 +2295,8 @@
             "arguments": [
                 "--url",
                 "https://curl.se/we/are.html?*=moo&user=many#more",
-                "--trim",
-                "query=\\*"
+                "--qtrim",
+                "\\*"
             ]
         },
         "expected": {

--- a/trurl.md
+++ b/trurl.md
@@ -231,6 +231,17 @@ Uses the punycode version of the hostname, which is how International Domain
 Names are converted into plain ASCII. If the hostname is not using IDN, the
 regular ASCII name is used.
 
+## --qtrim [what]
+
+Trims data off a query.
+
+*what* is specified as a full name of a name/value pair, or as a word prefix
+(using a single trailing asterisk (`*`)) which makes trurl remove the tuples
+from the query string that match the instruction.
+
+To match a literal trailing asterisk instead of using a wildcard, escape it
+with a backslash in front of it. Like `\\*`.
+
 ## --query-separator [what]
 
 Specify the single letter used for separating query pairs. The default is `&`
@@ -291,6 +302,8 @@ insensitive alphabetical order. This helps making URLs identical that
 otherwise only had their query pairs in different orders.
 
 ## --trim [component]=[what]
+
+Deprecated: use **--qtrim**.
 
 Trims data off a component. Currently this can only trim a query component.
 
@@ -546,9 +559,9 @@ them first at least increases the chances of it working:
     http://alpha/?one=real&three=alsoreal&two=fake
 
 Remove name/value pairs from the URL by specifying exact name or wildcard
-pattern with **--trim**:
+pattern with **--qtrim**:
 
-    $ trurl 'https://example.com?a12=hej&a23=moo&b12=foo' --trim 'query=a*'
+    $ trurl 'https://example.com?a12=hej&a23=moo&b12=foo' --qtrim a*'
     https://example.com/?b12=foo
 
 ## fragment
@@ -746,7 +759,7 @@ $ trurl "https://fake.host/search?q=answers&user=me#frag" --json
 ## Remove tracking tuples from query
 
 ~~~
-$ trurl "https://curl.se?search=hey&utm_source=tracker" --trim query="utm_*"
+$ trurl "https://curl.se?search=hey&utm_source=tracker" --qtrim "utm_*"
 https://curl.se/?search=hey
 ~~~
 
@@ -767,7 +780,7 @@ https://example.com?a=c&b=a&c=b
 ## Work with a query that uses a semicolon separator
 
 ~~~
-$ trurl "https://curl.se?search=fool;page=5" --trim query="search" --query-separator ";"
+$ trurl "https://curl.se?search=fool;page=5" --qtrim "search" --query-separator ";"
 https://curl.se?page=5
 ~~~
 
@@ -821,7 +834,7 @@ Could not output a valid URL
 
 ## 8
 
-A problem with --trim
+A problem with --qtrim
 
 ## 9
 


### PR DESCRIPTION
--trim is now deprecated. When we added that we thought we would trim other components over time but that has not materialized. Switching to --qtrim makes for easier command lines with no functionality loss.

--trim is no longer displayed in the help output but is still tested in several test cases.