### PR TITLE
COPYING: add the "and many contributors" text from the curl license

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,7 @@
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright (c) 2023 - 2024, Daniel Stenberg, <daniel@haxx.se>
+Copyright (c) 2023 - 2024, Daniel Stenberg, <daniel@haxx.se>, and many
+contributors, see the THANKS file.
 
 All rights reserved.
 


### PR DESCRIPTION
Makes them identically phrased.

Fixes #365
Reported-by: Carlos Henrique Lima Melara