### PR TITLE
Generate ZSH completions base on trurl.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # compiled program
 /trurl
+/trurl.1
+_trurl.zsh
 
 # Prerequisites
 *.d
@@ -60,3 +62,6 @@ winbuild/obj/
 
 # Dependencies for msvc from vcpkg
 winbuild/vcpkg_installed/
+
+# vim
+*.sw*

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ MANUAL = trurl.1
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man/man1
+ZSH_COMPLETIONSDIR ?= $(PREFIX)/share/zsh/site-functions
+COMPLETION_FILES=completions/_trurl.zsh
 
 INSTALL ?= install
 PYTHON3 ?= python3
@@ -55,10 +57,14 @@ install:
 	(if test -f $(MANUAL); then \
 	$(INSTALL) -m 0644 $(MANUAL) $(DESTDIR)$(MANDIR); \
 	fi)
+	(if test -f $(COMPLETION_FILES); then \
+	$(INSTALL) -d $(DESTDIR)$(ZSH_COMPLETIONSDIR); \
+	$(INSTALL) -m 0755 $(COMPLETION_FILES) $(ZSH_COMPLETIONSDIR)/_trurl; \
+	fi)
 
 .PHONY: clean
 clean:
-	rm -f $(OBJS) $(TARGET)
+	rm -f $(OBJS) $(TARGET) $(COMPLETION_FILES)
 
 .PHONY: test
 test: $(TARGET)
@@ -71,3 +77,7 @@ test-memory: $(TARGET)
 .PHONY: checksrc
 checksrc:
 	./checksrc.pl trurl.c version.h
+
+.PHONY: completions
+completions: trurl.md
+	./completions/generate_completions.sh $^

--- a/completions/_trurl.zsh.in
+++ b/completions/_trurl.zsh.in
@@ -1,0 +1,66 @@
+#compdef trurl
+##########################################################################
+#                             _                   _
+#  Project                   | |_ _ __ _   _ _ __| |
+#                            | __| '__| | | | '__| |
+#                            | |_| |  | |_| | |  | |
+#                             \__|_|   \__,_|_|  |_|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+##########################################################################
+
+
+# This file is generated from trurls generate_completions.sh
+
+# standalone flags - things that have now follow on 
+standalone_flags=(@TRURL_STANDALONE_FLAGS@)
+
+# component options - flags that expected to come after them
+component_options=(@TRURL_COMPONENT_OPTIONS@)
+
+# components that take *something* as a param but we can't
+# be sure what
+random_options=(@TRURL_RANDOM_OPTIONS@)
+
+# Components are specific URL parts that are only completed
+# after a component_options appears
+component_list=( @TRURL_COMPONENT_LIST@)
+
+if (( "${component_options[(Ie)${words[$CURRENT-1]}]}" )); then
+    compadd -S "=" "${component_list[@]}"
+    return 0
+fi
+
+# if we expect another parameter that trurl doesn't define then
+# we should (i.e. a component) then fall back on ZSH _path_file
+if (( "${random_options[(Ie)${words[$CURRENT-1]}]}" )); then
+    _path_files
+    return 0
+fi
+
+# calling compadd directly allows us the let the flags be 
+# repeatable so we can recall --set, --get etc. 
+repeatable=( "${component_options[@]}" "${random_options[@]}" )
+args=( "${repeatable[@]}" )
+# only apply single completions which haven't been used. 
+for sf in "${standalone_flags[@]}"; do
+    if ! (( "${words[(Ie)$sf]}" ));  then
+        args+=("$sf")
+    fi
+done
+
+compadd "${args[@]}"

--- a/completions/generate_completions.sh
+++ b/completions/generate_completions.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+##########################################################################
+#                             _                   _
+#  Project                   | |_ _ __ _   _ _ __| |
+#                            | __| '__| | | | '__| |
+#                            | |_| |  | |_| | |  | |
+#                             \__|_|   \__,_|_|  |_|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+##########################################################################
+
+
+if [ -z "$1" ]; then
+    echo "expected a trurl.md file to be passed in..."
+    exit 1
+fi
+
+TRURL_MD_FILE=$1
+
+
+
+ALL_FLAGS="$(sed  -n \
+        -e 's/"//g' \
+        -e '/\# URL COMPONENTS/q;p' \
+        < "${TRURL_MD_FILE}" \
+    | grep "##" \
+    | awk '{printf "%s%s%s%s ", $2, $3, $4, $5}')"
+
+
+TRURL_COMPONENT_OPTIONS=""
+TRURL_STANDALONE_FLAGS=""
+TRURL_RANDOM_OPTIONS=""
+TRURL_COMPONENT_LIST="$(sed -n \
+      -e 's/"//g' \
+      -e '1,/\# URL COMPONENTS/ d' \
+      -e '/\# JSON output format/q;p' \
+      < "${TRURL_MD_FILE}" \
+    | grep "##" \
+    | awk '{printf "\"%s\" ", $2}')"
+
+for flag in $ALL_FLAGS; do
+  # these are now TRURL_STANDALONE 
+  if echo "$flag" | grep -q "="; then
+    TRURL_COMPONENT_OPTIONS+="$(echo "$flag" \
+    | awk '{split($0, a, ","); for(i in a) {printf "%s ", a[i]}}' \
+    | cut -f1 -d '[' \
+    | awk '{printf "\"%s\" ",  $1}')"
+  elif echo "$flag" | grep -q "\["; then
+    TRURL_RANDOM_OPTIONS+="$(echo "$flag" \
+    | awk '{split($0, a, ","); for(i in a) {printf "%s ", a[i]}}' \
+    | cut -f1 -d '[' \
+    | awk '{printf "\"%s\" ", $1}')"
+  else
+    TRURL_STANDALONE_FLAGS+="$(echo "$flag" \
+    | awk '{split($0, a, ","); for(i in a) {printf "\"%s\" ",  a[i]}}')"
+  fi
+done
+
+function generate_zsh() {
+    sed -e "s/@TRURL_RANDOM_OPTIONS@/${TRURL_RANDOM_OPTIONS}/g" \
+      -e "s/@TRURL_STANDALONE_FLAGS@/${TRURL_STANDALONE_FLAGS}/g" \
+      -e "s/@TRURL_COMPONENT_OPTIONS@/${TRURL_COMPONENT_OPTIONS}/g" \
+      -e "s/@TRURL_COMPONENT_LIST@/${TRURL_COMPONENT_LIST}/g" \
+      ./completions/_trurl.zsh.in  > ./completions/_trurl.zsh
+}
+
+generate_zsh "$TRURL_RANDOM_OPTIONS"


### PR DESCRIPTION
This PR introduces a script `generate_completions.sh` which extracts the command line options from `trurl.md` and sorts them in to different buckets: standalone (things like `--json`, `--accept-space`), component options (things like `--set`, `--iterate` which take a `component=` directly after), _random options_ (things like `--qtrim`, `--url-file` that take an option but we don't control what it is), and the components. The _trurl.zsh.in is a template that these different list of options are inserted into. 

I also added a `completions` task to the Makefile, and updated the install to copy them to `/usr/local/share/zsh/site-functions` if the completion has been built. 