### PR TITLE
Makefile: only create MANDIR when manpage is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ trurl.o: trurl.c version.h
 install:
 	$(INSTALL) -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
-	$(INSTALL) -d $(DESTDIR)$(MANDIR)
 	(if test -f $(MANUAL); then \
+	$(INSTALL) -d $(DESTDIR)$(MANDIR); \
 	$(INSTALL) -m 0644 $(MANUAL) $(DESTDIR)$(MANDIR); \
 	fi)
 	(if test -f $(COMPLETION_FILES); then \


### PR DESCRIPTION
When not installing the manpage there is no use in creating the directory

Fixes f3523912562 Makefile: check for trurl.1 before installing