### PR TITLE
introduce 'excludes' option for tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -250,11 +250,16 @@ def main(argc, argv):
                 print(f"Missing feature, skipping test {testIndex + 1}.")
                 numTestsSkipped += 1
                 continue
+            excludes = allTests[testIndex].get("excludes", None) 
+            if excludes and set(excludes).issubset(set(features)):
+                print(f"Test not compatible, skipping test {testIndex + 1}")
+                numTestsSkipped += 1
+                continue
             encoding = allTests[testIndex].get("encoding", None)
             if encoding and encoding != getcharmap():
                 print(f"Invalid locale, skipping test {testIndex + 1}.")
                 numTestsSkipped += 1
-                continue;
+                continue
 
             test = TestCase(testIndex + 1, runnerCmd, baseCmd, **allTests[testIndex])
 

--- a/tests.json
+++ b/tests.json
@@ -702,6 +702,7 @@
                 "user=:hej:"
             ]
         },
+        "excludes": ["uppercase-hex"],
         "expected": {
             "stdout": "https://%3ahej%3a@curl.se/hello\n",
             "stderr": "",
@@ -2030,6 +2031,7 @@
                 "localhost"
             ]
         },
+        "excludes": ["uppercase-hex"],
         "expected": {
             "stdout": "/\\\\\n/%5c%5c\n",
             "returncode": 0,
@@ -2045,6 +2047,7 @@
                 "localhost"
             ]
         },
+        "excludes": ["uppercase-hex"],
         "expected": {
             "stdout": [
                 {
@@ -2071,6 +2074,7 @@
                 "localhost"
             ]
         },
+        "excludes": ["uppercase-hex"],
         "expected": {
             "stdout": "/%5c%5c\n/%5c%5c\n",
             "returncode": 0,
@@ -2089,6 +2093,7 @@
                 "localhost"
             ]
         },
+        "excludes": ["uppercase-hex"],
         "expected": {
             "stdout": [
                 {
@@ -3317,6 +3322,125 @@
         "expected": {
             "stdout": "http://e/?e&a\n",
             "returncode": 0
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "path=\\\\",
+                "--json",
+                "localhost"
+            ]
+        },
+        "required": ["uppercase-hex"],
+        "expected": {
+            "stdout": [
+                {
+                    "url": "http://localhost/%5C%5C",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "localhost",
+                        "path": "/\\\\"
+                    }
+                }
+            ],
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "path=\\\\",
+                "-g",
+                "{path}\\n{:path}",
+                "--urlencode",
+                "localhost"
+            ]
+        },
+        "required": ["uppercase-hex"],
+        "expected": {
+            "stdout": "/%5C%5C\n/%5C%5C\n",
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "path=abc\\\\",
+                "-s",
+                "query:=a&b&a%26b",
+                "--urlencode",
+                "--json",
+                "localhost"
+            ]
+        },
+        "required": ["uppercase-hex"],
+        "expected": {
+            "stdout": [
+                {
+                    "url": "http://localhost/abc%5C%5C?a&b&a%26b",
+                    "parts": {
+                        "scheme": "http",
+                        "host": "localhost",
+                        "path": "/abc%5C%5C",
+                        "query": "a&b&a%26b"
+                    },
+                    "params": [
+                        {
+                            "key": "a",
+                            "value": ""
+                        },
+                        {
+                            "key": "b",
+                            "value": ""
+                        },
+                        {
+                            "key": "a&b",
+                            "value": ""
+                        }
+                    ]
+                }
+            ],
+            "returncode": 0,
+            "stderr": ""
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "--url",
+                "https://curl.se/hello",
+                "--set",
+                "user=:hej:"
+            ]
+        },
+        "required": ["uppercase-hex"],
+        "expected": {
+            "stdout": "https://%3Ahej%3A@curl.se/hello\n",
+            "stderr": "",
+            "returncode": 0
+        }
+    },
+    {
+        "input": {
+            "arguments": [
+                "-s",
+                "path=\\\\",
+                "-g",
+                "{path}\\n{:path}",
+                "localhost"
+            ]
+        },
+        "required": ["uppercase-hex"],
+        "expected": {
+            "stdout": "/\\\\\n/%5C%5C\n",
+            "returncode": 0,
+            "stderr": ""
         }
     }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -316,6 +316,8 @@ static void show_version(void)
 #ifdef SUPPORTS_ZONEID
   fprintf(stdout, " zone-id");
 #endif
+  if(data->version_num >= 0x080f00)
+    fprintf(stdout, " uppercase-hex");
 
   fprintf(stdout, "\n");
   exit(0);


### PR DESCRIPTION
Addresses hexadecimal changes from curl 8.15. I've also duplicated the tests that were failing with the new uppercase hex values. 

Thanks @charles2910 for reporting this bug
fixes: #394