### PR TITLE
cmake: shorten option to `TRURL_MANUAL`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 #
 # Options:
 #
-# - `TRURL_ENABLE_MANUAL`:    Build the trurl man page (requires Perl). Default: `ON`
+# - `TRURL_MANUAL`:           Build the trurl man page (requires Perl). Default: `ON`
 # - `TRURL_COMPLETION_ZSH`:   Install zsh completions (requires POSIX shell). Default: `OFF`
 # - `TRURL_TESTS`:            Run tests (requires Python). Default: `ON`
 #                             Test targets:
@@ -124,8 +124,8 @@ endif()
 
 # Manual
 
-option(TRURL_ENABLE_MANUAL "Build the trurl man page (requires Perl)" ON)
-if(TRURL_ENABLE_MANUAL)
+option(TRURL_MANUAL "Build the trurl man page (requires Perl)" ON)
+if(TRURL_MANUAL)
   find_package(Perl)
   if(NOT Perl_FOUND)
     message(WARNING "Perl not found, cannot build the man page.")


### PR DESCRIPTION
Also fixing a bad typo in the original name.

Follow-up to 9fe363e4bd82828536d5b5d50f27646cc9a8feed #400
