### PR TITLE
add `SECURITY.md`, pointing to GitHub PVR

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,13 +4,9 @@ SPDX-License-Identifier: curl
 -->
 # Security Policy
 
-See curl's
-[SECURITY-PROCESS.md](https://github.com/curl/curl/blob/master/docs/SECURITY-PROCESS.md)
-for full details.
-
 ## Reporting a Vulnerability
 
 If you have found or just suspect a security problem somewhere in trurl,
-report it on [https://hackerone.com/curl](https://hackerone.com/curl).
+report it via <https://github.com/curl/trurl/security>.
 
 We treat security issues with confidentiality until controlled and disclosed responsibly.


### PR DESCRIPTION
---

Initial PR adds a slightly modified copy of curl-for-win's:
https://github.com/curl/curl-for-win/blob/4e04d83e8ddaaa4db9b6b6d999cfca3897fb0f8e/SECURITY.md

which is in turn a adaptation from curl's:
https://github.com/curl/curl/blob/4d93592a26e31ea5632b98281225807b9f938460/SECURITY.md

To decide:
- if we desire one for trurl? [YES]
- if trurl accepts security reports in a special channel? [YES]
- if so, which channel would it be? (Hackerone, perhaps GitHub, other) [PVR]
