### PR TITLE
cmake: fix one more option name typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@
 #                             Test targets:
 #                             - `trurl-test`:        Run tests.
 #                             - `trurl-test-memory`: Run tests with valgrind.
-# - `TURLS_DISABLE_INSTALL`:  Disable installation targets. Default `OFF`
+# - `TRURL_DISABLE_INSTALL`:  Disable installation targets. Default `OFF`
 # - `TRURL_WERROR`:           Turn compiler warnings into errors. Default: `OFF`
 #
 # - `CURL_INCLUDE_DIR`:       Absolute path to curl include directory.
@@ -53,7 +53,7 @@ project(trurl VERSION "${trurl_version_str}" LANGUAGES C)
 
 # Install options
 
-option(TURLS_DISABLE_INSTALL "Disable installation targets" OFF)
+option(TRURL_DISABLE_INSTALL "Disable installation targets" OFF)
 if(NOT TRURL_DISABLE_INSTALL)
   include(GNUInstallDirs)
 endif()


### PR DESCRIPTION
Follow-up to 9fe363e4bd82828536d5b5d50f27646cc9a8feed #400