### PR TITLE
GHA/codeql: limit cron job to the origin repository

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,7 @@ permissions: {}
 
 jobs:
   gha_python:
+    if: ${{ github.repository_owner == 'curl' || github.event_name != 'schedule' }}
     name: 'GHA and Python'
     runs-on: ubuntu-latest
     permissions:
@@ -42,6 +43,7 @@ jobs:
         uses: github/codeql-action/analyze@v4
 
   c:
+    if: ${{ github.repository_owner == 'curl' || github.event_name != 'schedule' }}
     name: 'C'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
To avoid running it in every fork, every week.