### PR TITLE
test.py: More info in missing features output

### DIFF
--- a/test.py
+++ b/test.py
@@ -249,17 +249,17 @@ def main(argc, argv):
             # skip tests if required features are not met
             required = allTests[testIndex].get("required", None)
             if required and not set(required).issubset(set(features)):
-                print(f"Missing feature, skipping test {testIndex + 1}.")
+                print(f"Missing feature {','.join(required)}, skipping test {testIndex + 1}.")
                 numTestsSkipped += 1
                 continue
             excludes = allTests[testIndex].get("excludes", None)
             if excludes and set(excludes).issubset(set(features)):
-                print(f"Test not compatible, skipping test {testIndex + 1}")
+                print(f"Test not compatible with {','.join(excludes)}, skipping test {testIndex + 1}")
                 numTestsSkipped += 1
                 continue
             encoding = allTests[testIndex].get("encoding", None)
             if encoding and encoding != getcharmap():
-                print(f"Invalid locale, skipping test {testIndex + 1}.")
+                print(f"Invalid locale {encoding}, skipping test {testIndex + 1}.")
                 numTestsSkipped += 1
                 continue
 


### PR DESCRIPTION
I was doing some do-no-harm testing for the latest curl rc* and noticed the tests could provide more descriptive output when they are skipped. Currently, when a test is skipped you have to go and look through `tests.json` , find the right test, and then check what features trurl  has available  to know why it was skipped.

 This PR adds the conflicting feature to the test output. for example if libcurl doesn't support punycode decoding the tests will output:
```
Missing feature punycode2idn, skipping test 141.
Missing feature punycode2idn, skipping test 142.
```

*I didn't find anything unusual when testing trurl with curl 8.18-rc2