### PR TITLE
tests.json: skip imap test when no `imap-options`

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -3086,6 +3086,9 @@
         "imap://us%65r:pwd;gir%41ffe@odd"
       ]
     },
+    "required": [
+      "imap-options"
+    ],
     "expected": {
       "stdout": "imap://user:pwd;girAffe@odd/\n",
       "stderr": "",


### PR DESCRIPTION
Fixing:
```
trurl version 0.16.1 libcurl/8.18.0 [built-with 8.18.0]
features: get-empty no-guess-scheme normalize-ipv4 url-strerror white-space zone-id uppercase-hex
[...]
186: failed	'imap://us%65r:pwd;gir%41ffe@odd'
--- stdout --- 
expected:
'imap://user:pwd;girAffe@odd/\n'
got:
'imap://user:pwd%3bgirAffe@odd/\n'
```
