### PR TITLE
GHA/curl-for-win: tidy up build configuration, drop artifacts

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -23,6 +23,7 @@ env:
   CW_MAP: '0'
   CW_JOBS: '5'
   CW_TRURL_TEST: '1'
+  CW_NOPKG: '1'
 
 jobs:
   win-llvm:


### PR DESCRIPTION
In 2025, curl-for-win gained support for building trurl with
a minimized, trurl-specific libcurl. `CW_CONFIG` no longer affects how
curl is built for trurl.

Delete most of the local configuration, keeping just enough to avoid
downloading 3rd-party libraries, and disable building the default curl.
Plus operating system and CPU targets specific for the trurl repo.

After this, trurl and the trurl-specific libcurl are the only targets
produced, and built automatically using curl-for-win configuration.

Also:
- make `CW_TRURL_TEST` a global env to apply to all curl-for-win jobs
  automatically.
- stop uploading trurl artifacts. Find them now under the curl-for-win
  repo: https://github.com/curl/curl-for-win/actions/workflows/daily.yml
