### PR TITLE
fixing strncmp length for imap protocol detection

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -292,7 +292,7 @@ TRURL_NORETURN static void show_version(void)
   const char * const *protocol_name = data->protocols;
   supports_imap = false;
   while(*protocol_name && !supports_imap) {
-    supports_imap = !strncmp(*protocol_name, "imap", 3);
+    supports_imap = !strncmp(*protocol_name, "imap", 4);
     protocol_name++;
   }
 #endif


### PR DESCRIPTION
The strncmp call comparing protocol names against "imap" used length 3 instead of 4. This would match any protocol starting with "ima", which is incorrect. The code should use 4 to correctly match "imap" (and its prefix in "imaps").