### PR TITLE
Freeqpairs, fixing memry leak for trimmed/replaced query pairs

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -3520,5 +3520,21 @@
       "returncode": 0,
       "stderr": ""
     }
+  },
+  {
+    "input": {
+      "arguments": [
+        "https://example.com/?a=1&b=2&c=3",
+        "--qtrim",
+        "b",
+        "--get",
+        "{query}"
+      ]
+    },
+    "expected": {
+      "stdout": "a=1&c=3\n",
+      "returncode": 0,
+      "stderr": ""
+    }
   }
 ]

--- a/trurl.c
+++ b/trurl.c
@@ -1508,7 +1508,7 @@ static void freeqpairs(void)
 {
   size_t i;
   for(i = 0; i < nqpairs; i++) {
-    if(qpairs[i].len) {
+    if(qpairs[i].str) {
       free(qpairs[i].str);
       qpairs[i].str = NULL;
       free(qpairsdec[i].str);


### PR DESCRIPTION
When trim() or replace() marks a query pair as deleted, they set len = 0 but allocate a new str via xstrdup(""). Since freeqpairs() only freed entries where len != 0, those strdup'd empty strings were leaked.

The fix is quite easy just check str (non-NULL) instead of len (non-zero) as the guard for freeing.

Add a test that trims a middle query key to exercise this code path.