### PR TITLE
tests: mark some additional tests uppercase-hex sensitive

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -764,8 +764,29 @@
         "query=user=me"
       ]
     },
+    "excludes": [
+      "uppercase-hex"
+    ],
     "expected": {
       "stdout": "https://curl.se/hello?user%3dme\n",
+      "stderr": "",
+      "returncode": 0
+    }
+  },
+  {
+    "input": {
+      "arguments": [
+        "--url",
+        "https://curl.se/hello",
+        "--set",
+        "query=user=me"
+      ]
+    },
+    "required": [
+      "uppercase-hex"
+    ],
+    "expected": {
+      "stdout": "https://curl.se/hello?user%3Dme\n",
       "stderr": "",
       "returncode": 0
     }
@@ -2183,8 +2204,33 @@
         "query:=a&b&a%26b"
       ]
     },
+    "excludes": [
+      "uppercase-hex"
+    ],
     "expected": {
       "stdout": "http://localhost/ABC%5c%5c?a&b&a%26b\n",
+      "returncode": 0,
+      "stderr": ""
+    }
+  },
+  {
+    "input": {
+      "arguments": [
+        "-s",
+        "scheme:=http",
+        "-s",
+        "host:=localhost",
+        "-s",
+        "path:=/ABC%5C%5C",
+        "-s",
+        "query:=a&b&a%26b"
+      ]
+    },
+    "required": [
+      "uppercase-hex"
+    ],
+    "expected": {
+      "stdout": "http://localhost/ABC%5C%5C?a&b&a%26b\n",
       "returncode": 0,
       "stderr": ""
     }
@@ -2891,8 +2937,28 @@
         "path=%61"
       ]
     },
+    "excludes": [
+      "uppercase-hex"
+    ],
     "expected": {
       "stdout": "https://example.com/one/tao/%2fB/%2561\n",
+      "stderr": "",
+      "returncode": 0
+    }
+  },
+  {
+    "input": {
+      "arguments": [
+        "https://example.com/one/t%61o/%2F%42/",
+        "--append",
+        "path=%61"
+      ]
+    },
+    "required": [
+      "uppercase-hex"
+    ],
+    "expected": {
+      "stdout": "https://example.com/one/tao/%2FB/%2561\n",
       "stderr": "",
       "returncode": 0
     }


### PR DESCRIPTION
Since 8.20.0, three more tests started to fail because of the case used to represent hex digits.

Fixes: #440