### PR TITLE
build: constify more to fix gcc-16 / glibc 2.43 builds

### DIFF
--- a/trurl.c
+++ b/trurl.c
@@ -342,7 +342,7 @@ struct iterinfo {
   CURLU *uh;
   const char *part;
   size_t plen;
-  char *ptr;
+  const char *ptr;
   unsigned int varmask; /* sets 1 << [component] */
 };
 
@@ -1825,7 +1825,7 @@ static void singleurl(struct option *o,
       const char *w;
       size_t wlen;
       const char *sep;
-      char *sepw;
+      const char *sepw;
       bool urlencode = true;
       const struct var *v;
 


### PR DESCRIPTION
Fixing:
```
trurl.c:1869:12: error: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 1869 |       sepw = strchr(w, ' ');
      |            ^
```
Ref: https://github.com/curl/trurl/actions/runs/29492873600/job/87602928996?pr=446#step:4:12

Reported-by: vpzomtrrfrt on github
Bug: https://github.com/curl/trurl/issues/430#issuecomment-4985712536
Follow-up to 6e1479cc3bdece8d9a7602e6f8f799305d5a5b7d #432
