### PR TITLE
GHA: use arm runner for valgrind job for better performance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,17 +24,19 @@ env:
 jobs:
   ubuntu:
     name: 'Linux'
-    runs-on: ubuntu-26.04
+    runs-on: ${{ matrix.build.image }}
 
     strategy:
       matrix:
         build:
           - name: 'default'
+            image: ubuntu-26.04-arm
             install_packages: gcc-16 valgrind
             test: test-memory
             CC: gcc-16
 
           - name: 'clang sanitizers'
+            image: ubuntu-26.04
             install_packages: clang-22
             test: test
             CC: clang-22


### PR DESCRIPTION
Brings down job time from slightly below 3 minutes to slighty above 2 
minutes.

Before: https://github.com/curl/trurl/actions/runs/29494514068/job/87608196588
After: https://github.com/curl/trurl/actions/runs/29495025970/job/87609886033
